### PR TITLE
[SYSML-307] Exclude servlet-api dependencies to avoid SecurityException

### DIFF
--- a/system-ml/pom.xml
+++ b/system-ml/pom.xml
@@ -402,12 +402,24 @@
 			<artifactId>hadoop-common</artifactId>
 			<version>2.4.0</version>
 			<scope>provided</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>javax.servlet</groupId>
+					<artifactId>servlet-api</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.hadoop</groupId>
 			<artifactId>hadoop-hdfs</artifactId>
 			<version>2.4.0</version>
 			<scope>provided</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>javax.servlet</groupId>
+					<artifactId>servlet-api</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>commons-logging</groupId>
@@ -503,6 +515,12 @@
 			<artifactId>hadoop-yarn-common</artifactId>
 			<version>2.4.1</version>
 			<scope>provided</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>javax.servlet</groupId>
+					<artifactId>servlet-api</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
There is a dependency library collision that can occur with the Servlet API libraries that Hadoop and Spark depend on. This can occur if I run a test (*.integration.functions.mlcontext.GNMFTest) from Eclipse that creates a SparkContext. This doesn't occur if I run the test from Maven. The error is:
`java.lang.SecurityException: class "javax.servlet.FilterRegistration"'s signer information does not match signer information of other classes in the same package`

The spark-core_2.10 dependency has a transitive dependency on org.eclipse.jetty.orbit:javax.servlet:3.0.0.v201112011016. The hadoop-common, hadoop-hdfs, and hadoop-yarn-common dependencies have transitive dependencies on javax.servlet:servlet-api. One potential solution to this issue is to exclude the hadoop dependencies on the servlet-api in the pom.xml file.

This is very similiar to: https://issues.apache.org/jira/browse/SPARK-1693

Mike is going to test the pom.xml modification on his Hadoop cluster to verify that it doesn't break SystemML in a clustered environment.

