### PR TITLE
[SYSML-306] Remove legacy _COPYRIGHT constants from Java classes

### DIFF
--- a/system-ml/src/main/java/com/ibm/bi/dml/parser/antlr4/DMLParserWrapper.java
+++ b/system-ml/src/main/java/com/ibm/bi/dml/parser/antlr4/DMLParserWrapper.java
@@ -84,9 +84,6 @@ import com.ibm.bi.dml.runtime.util.LocalFileUtils;
  *
  */
 public class DMLParserWrapper {
-	@SuppressWarnings("unused")
-	private static final String _COPYRIGHT = "Licensed Materials - Property of IBM\n(C) Copyright IBM Corp. 2010, 2015\n" +
-			"US Government Users Restricted Rights - Use, duplication  disclosure restricted by GSA ADP Schedule Contract with IBM Corp.";
 
 	private static final Log LOG = LogFactory.getLog(DMLScript.class.getName());
 	

--- a/system-ml/src/main/java/com/ibm/bi/dml/parser/python/PyDMLParserWrapper.java
+++ b/system-ml/src/main/java/com/ibm/bi/dml/parser/python/PyDMLParserWrapper.java
@@ -63,10 +63,6 @@ import com.ibm.bi.dml.parser.python.PydmlSyntacticErrorListener.CustomDmlErrorLi
  *
  */
 public class PyDMLParserWrapper {
-	@SuppressWarnings("unused")
-	private static final String _COPYRIGHT = "Licensed Materials - Property of IBM\n(C) Copyright IBM Corp. 2010, 2015\n" +
-			"US Government Users Restricted Rights - Use, duplication  disclosure restricted by GSA ADP Schedule Contract with IBM Corp.";
-
 
 	private static final Log LOG = LogFactory.getLog(DMLScript.class.getName());
 

--- a/system-ml/src/main/java/com/ibm/bi/dml/runtime/instructions/spark/CSVReblockSPInstruction.java
+++ b/system-ml/src/main/java/com/ibm/bi/dml/runtime/instructions/spark/CSVReblockSPInstruction.java
@@ -42,10 +42,6 @@ import com.ibm.bi.dml.runtime.matrix.operators.Operator;
 
 public class CSVReblockSPInstruction extends UnarySPInstruction {
 
-	@SuppressWarnings("unused")
-	private static final String _COPYRIGHT = "Licensed Materials - Property of IBM\n(C) Copyright IBM Corp. 2010, 2015\n"
-			+ "US Government Users Restricted Rights - Use, duplication  disclosure restricted by GSA ADP Schedule Contract with IBM Corp.";
-
 	private int brlen;
 	private int bclen;
 	private boolean hasHeader;

--- a/system-ml/src/main/java/com/ibm/bi/dml/runtime/instructions/spark/CentralMomentSPInstruction.java
+++ b/system-ml/src/main/java/com/ibm/bi/dml/runtime/instructions/spark/CentralMomentSPInstruction.java
@@ -196,9 +196,6 @@ public class CentralMomentSPInstruction extends UnarySPInstruction
 	
 	private static class RDDCMReduceFunction implements Function2<CM_COV_Object, CM_COV_Object, CM_COV_Object>
 	{
-		@SuppressWarnings("unused")
-		private static final String _COPYRIGHT = "Licensed Materials - Property of IBM\n(C) Copyright IBM Corp. 2010, 2015\n" +
-	                                             "US Government Users Restricted Rights - Use, duplication  disclosure restricted by GSA ADP Schedule Contract with IBM Corp.";
 
 		private static final long serialVersionUID = 3272260751983866544L;
 		

--- a/system-ml/src/main/java/com/ibm/bi/dml/runtime/io/BinaryBlockSerialization.java
+++ b/system-ml/src/main/java/com/ibm/bi/dml/runtime/io/BinaryBlockSerialization.java
@@ -38,10 +38,6 @@ import com.ibm.bi.dml.runtime.util.FastBufferedDataOutputStream;
 @SuppressWarnings("rawtypes")
 public class BinaryBlockSerialization implements Serialization
 {
-	@SuppressWarnings("unused")
-	private static final String _COPYRIGHT = "Licensed Materials - Property of IBM\n(C) Copyright IBM Corp. 2010, 2015\n" +
-	                                         "US Government Users Restricted Rights - Use, duplication  disclosure restricted by GSA ADP Schedule Contract with IBM Corp.";
-	
 	@Override
 	public boolean accept(Class arg0) 
 	{

--- a/system-ml/src/main/java/com/ibm/bi/dml/runtime/io/IOUtilFunctions.java
+++ b/system-ml/src/main/java/com/ibm/bi/dml/runtime/io/IOUtilFunctions.java
@@ -32,10 +32,6 @@ import com.ibm.bi.dml.runtime.util.UtilFunctions;
 
 public class IOUtilFunctions 
 {
-	@SuppressWarnings("unused")
-	private static final String _COPYRIGHT = "Licensed Materials - Property of IBM\n(C) Copyright IBM Corp. 2010, 2015\n" +
-	                                         "US Government Users Restricted Rights - Use, duplication  disclosure restricted by GSA ADP Schedule Contract with IBM Corp.";
-	
 	private static final Log LOG = LogFactory.getLog(UtilFunctions.class.getName());
 
 	

--- a/system-ml/src/main/java/com/ibm/bi/dml/runtime/io/ReaderTextCSVParallel.java
+++ b/system-ml/src/main/java/com/ibm/bi/dml/runtime/io/ReaderTextCSVParallel.java
@@ -56,9 +56,6 @@ import com.ibm.bi.dml.runtime.matrix.data.MatrixBlock;
  * 
  */
 public class ReaderTextCSVParallel extends MatrixReader {
-	@SuppressWarnings("unused")
-	private static final String _COPYRIGHT = "Licensed Materials - Property of IBM\n(C) Copyright IBM Corp. 2010, 2015\n"
-			+ "US Government Users Restricted Rights - Use, duplication  disclosure restricted by GSA ADP Schedule Contract with IBM Corp.";
 
 	private CSVFileFormatProperties _props = null;
 	private int _numThreads = 1;

--- a/system-ml/src/main/java/com/ibm/bi/dml/runtime/matrix/CMCOVMR.java
+++ b/system-ml/src/main/java/com/ibm/bi/dml/runtime/matrix/CMCOVMR.java
@@ -39,10 +39,6 @@ import com.ibm.bi.dml.runtime.matrix.mapred.MRJobConfiguration.ConvertTarget;
 
 public class CMCOVMR 
 {
-	@SuppressWarnings("unused")
-	private static final String _COPYRIGHT = "Licensed Materials - Property of IBM\n(C) Copyright IBM Corp. 2010, 2015\n" +
-	                                         "US Government Users Restricted Rights - Use, duplication  disclosure restricted by GSA ADP Schedule Contract with IBM Corp.";
-		
 	private static final Log LOG = LogFactory.getLog(CMCOVMR.class.getName());
 	
 	private CMCOVMR() {

--- a/system-ml/src/main/java/com/ibm/bi/dml/runtime/matrix/CSVReblockMR.java
+++ b/system-ml/src/main/java/com/ibm/bi/dml/runtime/matrix/CSVReblockMR.java
@@ -59,10 +59,6 @@ import com.ibm.bi.dml.runtime.util.MapReduceTool;
 @SuppressWarnings("deprecation")
 public class CSVReblockMR 
 {
-	@SuppressWarnings("unused")
-	private static final String _COPYRIGHT = "Licensed Materials - Property of IBM\n(C) Copyright IBM Corp. 2010, 2015\n" +
-	                                         "US Government Users Restricted Rights - Use, duplication  disclosure restricted by GSA ADP Schedule Contract with IBM Corp.";
-	
 	public static final String NUM_ROWS_IN_MATRIX="num.rows.in.matrix.";
 	public static final String NUM_COLS_IN_MATRIX="num.cols.in.matrix.";
 	public static final String ROWID_FILE_NAME="rowid.file.name";

--- a/system-ml/src/main/java/com/ibm/bi/dml/runtime/matrix/CleanupMR.java
+++ b/system-ml/src/main/java/com/ibm/bi/dml/runtime/matrix/CleanupMR.java
@@ -49,10 +49,6 @@ import com.ibm.bi.dml.runtime.util.LocalFileUtils;
 
 public class CleanupMR 
 {
-	@SuppressWarnings("unused")
-	private static final String _COPYRIGHT = "Licensed Materials - Property of IBM\n(C) Copyright IBM Corp. 2010, 2015\n" +
-	                                         "US Government Users Restricted Rights - Use, duplication  disclosure restricted by GSA ADP Schedule Contract with IBM Corp.";
-	
 	private static final Log LOG = LogFactory.getLog(CleanupMR.class.getName());
 	
 	private CleanupMR() {

--- a/system-ml/src/main/java/com/ibm/bi/dml/runtime/matrix/CombineMR.java
+++ b/system-ml/src/main/java/com/ibm/bi/dml/runtime/matrix/CombineMR.java
@@ -56,10 +56,6 @@ import com.ibm.bi.dml.runtime.util.UtilFunctions;
 
 public class CombineMR 
 {
-	@SuppressWarnings("unused")
-	private static final String _COPYRIGHT = "Licensed Materials - Property of IBM\n(C) Copyright IBM Corp. 2010, 2015\n" +
-	                                         "US Government Users Restricted Rights - Use, duplication  disclosure restricted by GSA ADP Schedule Contract with IBM Corp.";
-			
 	private static final Log LOG = LogFactory.getLog(CombineMR.class.getName());
 	
 	private CombineMR() {

--- a/system-ml/src/main/java/com/ibm/bi/dml/runtime/matrix/DataGenMR.java
+++ b/system-ml/src/main/java/com/ibm/bi/dml/runtime/matrix/DataGenMR.java
@@ -68,10 +68,6 @@ import com.ibm.bi.dml.yarn.ropt.YarnClusterAnalyzer;
  */
 public class DataGenMR
 {
-	@SuppressWarnings("unused")
-	private static final String _COPYRIGHT = "Licensed Materials - Property of IBM\n(C) Copyright IBM Corp. 2010, 2015\n" +
-	                                         "US Government Users Restricted Rights - Use, duplication  disclosure restricted by GSA ADP Schedule Contract with IBM Corp.";
-	
 	private static final Log LOG = LogFactory.getLog(DataGenMR.class.getName());
 	
 	private static IDSequence _seqRandInput = new IDSequence(); 

--- a/system-ml/src/main/java/com/ibm/bi/dml/runtime/matrix/DataPartitionMR.java
+++ b/system-ml/src/main/java/com/ibm/bi/dml/runtime/matrix/DataPartitionMR.java
@@ -30,10 +30,6 @@ import com.ibm.bi.dml.runtime.matrix.mapred.DistributedCacheInput;
 
 public class DataPartitionMR 
 {
-	@SuppressWarnings("unused")
-	private static final String _COPYRIGHT = "Licensed Materials - Property of IBM\n(C) Copyright IBM Corp. 2010, 2015\n" +
-	                                         "US Government Users Restricted Rights - Use, duplication  disclosure restricted by GSA ADP Schedule Contract with IBM Corp.";
-		
 	private DataPartitionMR() {
 		//prevent instantiation via private constructor
 	}

--- a/system-ml/src/main/java/com/ibm/bi/dml/runtime/matrix/GMR.java
+++ b/system-ml/src/main/java/com/ibm/bi/dml/runtime/matrix/GMR.java
@@ -66,10 +66,6 @@ import com.ibm.bi.dml.yarn.DMLAppMasterUtils;
  
 public class GMR
 {
-	@SuppressWarnings("unused")
-	private static final String _COPYRIGHT = "Licensed Materials - Property of IBM\n(C) Copyright IBM Corp. 2010, 2015\n" +
-	                                         "US Government Users Restricted Rights - Use, duplication  disclosure restricted by GSA ADP Schedule Contract with IBM Corp.";
-
 	private static final Log LOG = LogFactory.getLog(GMR.class.getName());
 		
 	private GMR() {

--- a/system-ml/src/main/java/com/ibm/bi/dml/runtime/matrix/GroupedAggMR.java
+++ b/system-ml/src/main/java/com/ibm/bi/dml/runtime/matrix/GroupedAggMR.java
@@ -40,10 +40,6 @@ import com.ibm.bi.dml.runtime.util.MapReduceTool;
 
 public class GroupedAggMR 
 {
-	@SuppressWarnings("unused")
-	private static final String _COPYRIGHT = "Licensed Materials - Property of IBM\n(C) Copyright IBM Corp. 2010, 2015\n" +
-	                                         "US Government Users Restricted Rights - Use, duplication  disclosure restricted by GSA ADP Schedule Contract with IBM Corp.";
-	
 	private static final Log LOG = LogFactory.getLog(GroupedAggMR.class.getName());
 	
 	private GroupedAggMR() {

--- a/system-ml/src/main/java/com/ibm/bi/dml/runtime/matrix/JobReturn.java
+++ b/system-ml/src/main/java/com/ibm/bi/dml/runtime/matrix/JobReturn.java
@@ -25,10 +25,6 @@ import com.ibm.bi.dml.runtime.matrix.data.OutputInfo;
 
 public class JobReturn 
 {
-	@SuppressWarnings("unused")
-	private static final String _COPYRIGHT = "Licensed Materials - Property of IBM\n(C) Copyright IBM Corp. 2010, 2015\n" +
-	                                         "US Government Users Restricted Rights - Use, duplication  disclosure restricted by GSA ADP Schedule Contract with IBM Corp.";
-		
 	public boolean successful;
 	// public MatrixCharacteristics[] stats;
 	// public MetaData[] otherMetadata=null;

--- a/system-ml/src/main/java/com/ibm/bi/dml/runtime/matrix/MMCJMR.java
+++ b/system-ml/src/main/java/com/ibm/bi/dml/runtime/matrix/MMCJMR.java
@@ -66,10 +66,6 @@ import com.ibm.bi.dml.yarn.ropt.YarnClusterAnalyzer;
  */
 public class MMCJMR 
 {
-	@SuppressWarnings("unused")
-	private static final String _COPYRIGHT = "Licensed Materials - Property of IBM\n(C) Copyright IBM Corp. 2010, 2015\n" +
-	                                         "US Government Users Restricted Rights - Use, duplication  disclosure restricted by GSA ADP Schedule Contract with IBM Corp.";
-
 	private static final boolean AUTOMATIC_CONFIG_NUM_REDUCERS = true;
 	private static final Log LOG = LogFactory.getLog(MMCJMR.class);
 

--- a/system-ml/src/main/java/com/ibm/bi/dml/runtime/matrix/MMRJMR.java
+++ b/system-ml/src/main/java/com/ibm/bi/dml/runtime/matrix/MMRJMR.java
@@ -62,10 +62,6 @@ import com.ibm.bi.dml.yarn.DMLAppMasterUtils;
  */
 public class MMRJMR 
 {
-	@SuppressWarnings("unused")
-	private static final String _COPYRIGHT = "Licensed Materials - Property of IBM\n(C) Copyright IBM Corp. 2010, 2015\n" +
-	                                         "US Government Users Restricted Rights - Use, duplication  disclosure restricted by GSA ADP Schedule Contract with IBM Corp.";
-			
 	private static final Log LOG = LogFactory.getLog(MMRJMR.class.getName());
 	
 	private MMRJMR() {

--- a/system-ml/src/main/java/com/ibm/bi/dml/runtime/matrix/MatrixCharacteristics.java
+++ b/system-ml/src/main/java/com/ibm/bi/dml/runtime/matrix/MatrixCharacteristics.java
@@ -68,10 +68,6 @@ public class MatrixCharacteristics implements Serializable
 {
 	private static final long serialVersionUID = 8300479822915546000L;
 
-	@SuppressWarnings("unused")
-	private static final String _COPYRIGHT = "Licensed Materials - Property of IBM\n(C) Copyright IBM Corp. 2010, 2015\n" +
-	                                         "US Government Users Restricted Rights - Use, duplication  disclosure restricted by GSA ADP Schedule Contract with IBM Corp.";
-		
 	private long numRows = -1;
 	private long numColumns = -1;
 	private int numRowsPerBlock = 1;

--- a/system-ml/src/main/java/com/ibm/bi/dml/runtime/matrix/MatrixDimensionsMetaData.java
+++ b/system-ml/src/main/java/com/ibm/bi/dml/runtime/matrix/MatrixDimensionsMetaData.java
@@ -20,10 +20,6 @@ package com.ibm.bi.dml.runtime.matrix;
 
 public class MatrixDimensionsMetaData extends MetaData 
 {
-	@SuppressWarnings("unused")
-	private static final String _COPYRIGHT = "Licensed Materials - Property of IBM\n(C) Copyright IBM Corp. 2010, 2015\n" +
-	                                         "US Government Users Restricted Rights - Use, duplication  disclosure restricted by GSA ADP Schedule Contract with IBM Corp.";
-		
 	protected MatrixCharacteristics matchar;
 	
 	public MatrixDimensionsMetaData() {

--- a/system-ml/src/main/java/com/ibm/bi/dml/runtime/matrix/MatrixFormatMetaData.java
+++ b/system-ml/src/main/java/com/ibm/bi/dml/runtime/matrix/MatrixFormatMetaData.java
@@ -23,10 +23,6 @@ import com.ibm.bi.dml.runtime.matrix.data.OutputInfo;
 
 public class MatrixFormatMetaData extends MatrixDimensionsMetaData 
 {
-	@SuppressWarnings("unused")
-	private static final String _COPYRIGHT = "Licensed Materials - Property of IBM\n(C) Copyright IBM Corp. 2010, 2015\n" +
-	                                         "US Government Users Restricted Rights - Use, duplication  disclosure restricted by GSA ADP Schedule Contract with IBM Corp.";
-		
 	private InputInfo iinfo;
 	private OutputInfo oinfo;
 	

--- a/system-ml/src/main/java/com/ibm/bi/dml/runtime/matrix/MetaData.java
+++ b/system-ml/src/main/java/com/ibm/bi/dml/runtime/matrix/MetaData.java
@@ -26,10 +26,6 @@ package com.ibm.bi.dml.runtime.matrix;
 
 public abstract class MetaData
 {
-	@SuppressWarnings("unused")
-	private static final String _COPYRIGHT = "Licensed Materials - Property of IBM\n(C) Copyright IBM Corp. 2010, 2015\n" +
-	                                         "US Government Users Restricted Rights - Use, duplication  disclosure restricted by GSA ADP Schedule Contract with IBM Corp.";
-			
 	@Override
 	public abstract boolean equals (Object anObject);
 	

--- a/system-ml/src/main/java/com/ibm/bi/dml/runtime/matrix/ReblockMR.java
+++ b/system-ml/src/main/java/com/ibm/bi/dml/runtime/matrix/ReblockMR.java
@@ -62,10 +62,6 @@ import com.ibm.bi.dml.yarn.ropt.YarnClusterAnalyzer;
 
 public class ReblockMR 
 {
-	@SuppressWarnings("unused")
-	private static final String _COPYRIGHT = "Licensed Materials - Property of IBM\n(C) Copyright IBM Corp. 2010, 2015\n" +
-	                                         "US Government Users Restricted Rights - Use, duplication  disclosure restricted by GSA ADP Schedule Contract with IBM Corp.";
-		
 	private static final Log LOG = LogFactory.getLog(ReblockMR.class.getName());
 	
 	private ReblockMR() {

--- a/system-ml/src/main/java/com/ibm/bi/dml/runtime/matrix/SortMR.java
+++ b/system-ml/src/main/java/com/ibm/bi/dml/runtime/matrix/SortMR.java
@@ -77,11 +77,6 @@ import com.ibm.bi.dml.runtime.util.MapReduceTool;
 @SuppressWarnings("deprecation")
 public class SortMR 
 {
-
-    @SuppressWarnings("unused")
-	private static final String _COPYRIGHT = "Licensed Materials - Property of IBM\n(C) Copyright IBM Corp. 2010, 2015\n" +
-	                                         "US Government Users Restricted Rights - Use, duplication  disclosure restricted by GSA ADP Schedule Contract with IBM Corp.";
-	
     private static final Log LOG = LogFactory.getLog(SortMR.class.getName());
     
     public static final String NUM_VALUES_PREFIX="num.values.in";

--- a/system-ml/src/main/java/com/ibm/bi/dml/runtime/matrix/data/PoissonRandomMatrixGenerator.java
+++ b/system-ml/src/main/java/com/ibm/bi/dml/runtime/matrix/data/PoissonRandomMatrixGenerator.java
@@ -22,10 +22,6 @@ import com.ibm.bi.dml.runtime.util.PoissonPRNGenerator;
 
 public class PoissonRandomMatrixGenerator extends RandomMatrixGenerator {
 
-	@SuppressWarnings("unused")
-	private static final String _COPYRIGHT = "Licensed Materials - Property of IBM\n(C) Copyright IBM Corp. 2010, 2014\n" +
-            "US Government Users Restricted Rights - Use, duplication  disclosure restricted by GSA ADP Schedule Contract with IBM Corp.";
-	
 	private double _mean=1.0;
 	
 	PoissonRandomMatrixGenerator(String pdf, int r, int c, int rpb, int cpb, double sp, double mean) throws DMLRuntimeException 

--- a/system-ml/src/main/java/com/ibm/bi/dml/runtime/matrix/data/RandomMatrixGenerator.java
+++ b/system-ml/src/main/java/com/ibm/bi/dml/runtime/matrix/data/RandomMatrixGenerator.java
@@ -25,10 +25,6 @@ import com.ibm.bi.dml.runtime.util.UniformPRNGenerator;
 
 public class RandomMatrixGenerator {
 	
-	@SuppressWarnings("unused")
-	private static final String _COPYRIGHT = "Licensed Materials - Property of IBM\n(C) Copyright IBM Corp. 2010, 2014\n" +
-            "US Government Users Restricted Rights - Use, duplication  disclosure restricted by GSA ADP Schedule Contract with IBM Corp.";
-	
 	String _pdf;
 	int _rows, _cols, _rowsPerBlock, _colsPerBlock;
 	double _sparsity, _mean; 

--- a/system-ml/src/main/java/com/ibm/bi/dml/runtime/util/BinaryBlockInputFormat.java
+++ b/system-ml/src/main/java/com/ibm/bi/dml/runtime/util/BinaryBlockInputFormat.java
@@ -36,10 +36,6 @@ import com.ibm.bi.dml.runtime.matrix.data.MatrixIndexes;
  */
 public class BinaryBlockInputFormat extends SequenceFileInputFormat<MatrixIndexes,MatrixBlock>
 {
-	@SuppressWarnings("unused")
-	private static final String _COPYRIGHT = "Licensed Materials - Property of IBM\n(C) Copyright IBM Corp. 2010, 2014\n" +
-	                                         "US Government Users Restricted Rights - Use, duplication  disclosure restricted by GSA ADP Schedule Contract with IBM Corp.";
-	
     @Override
 	public RecordReader<MatrixIndexes, MatrixBlock> getRecordReader(InputSplit split, JobConf job, Reporter reporter)
 		throws IOException 

--- a/system-ml/src/main/java/com/ibm/bi/dml/runtime/util/BinaryBlockRecordReader.java
+++ b/system-ml/src/main/java/com/ibm/bi/dml/runtime/util/BinaryBlockRecordReader.java
@@ -34,10 +34,6 @@ import com.ibm.bi.dml.runtime.matrix.data.MatrixIndexes;
  */
 public class BinaryBlockRecordReader extends SequenceFileRecordReader<MatrixIndexes,MatrixBlock>
 {
-	@SuppressWarnings("unused")
-	private static final String _COPYRIGHT = "Licensed Materials - Property of IBM\n(C) Copyright IBM Corp. 2010, 2014\n" +
-	                                         "US Government Users Restricted Rights - Use, duplication  disclosure restricted by GSA ADP Schedule Contract with IBM Corp.";
-	
 	//private long _time = 0;
 	
 	public BinaryBlockRecordReader(Configuration conf, FileSplit split)

--- a/system-ml/src/main/java/com/ibm/bi/dml/runtime/util/DataConverter.java
+++ b/system-ml/src/main/java/com/ibm/bi/dml/runtime/util/DataConverter.java
@@ -53,10 +53,6 @@ import com.ibm.bi.dml.udf.Matrix;
  */
 public class DataConverter 
 {
-	@SuppressWarnings("unused")
-	private static final String _COPYRIGHT = "Licensed Materials - Property of IBM\n(C) Copyright IBM Corp. 2010, 2015\n" +
-	                                         "US Government Users Restricted Rights - Use, duplication  disclosure restricted by GSA ADP Schedule Contract with IBM Corp.";
-		
 	
 	//////////////
 	// READING and WRITING of matrix blocks to/from HDFS

--- a/system-ml/src/main/java/com/ibm/bi/dml/runtime/util/FastBufferedDataOutputStream.java
+++ b/system-ml/src/main/java/com/ibm/bi/dml/runtime/util/FastBufferedDataOutputStream.java
@@ -38,10 +38,6 @@ import com.ibm.bi.dml.runtime.matrix.data.SparseRow;
  */
 public class FastBufferedDataOutputStream extends FilterOutputStream implements DataOutput, MatrixBlockDataOutput
 {
-	@SuppressWarnings("unused")
-	private static final String _COPYRIGHT = "Licensed Materials - Property of IBM\n(C) Copyright IBM Corp. 2010, 2015\n" +
-	                                         "US Government Users Restricted Rights - Use, duplication  disclosure restricted by GSA ADP Schedule Contract with IBM Corp.";
-		
 	protected byte[] _buff;
 	protected int _bufflen;
 	protected int _count;

--- a/system-ml/src/main/java/com/ibm/bi/dml/runtime/util/FastStringTokenizer.java
+++ b/system-ml/src/main/java/com/ibm/bi/dml/runtime/util/FastStringTokenizer.java
@@ -27,10 +27,6 @@ import java.util.NoSuchElementException;
  */
 public class FastStringTokenizer
 {
-	@SuppressWarnings("unused")
-	private static final String _COPYRIGHT = "Licensed Materials - Property of IBM\n(C) Copyright IBM Corp. 2010, 2015\n" +
-	                                         "US Government Users Restricted Rights - Use, duplication  disclosure restricted by GSA ADP Schedule Contract with IBM Corp.";
-	
 	private String _string = null;
     private char   _del    = 0;
     private int    _pos    = -1;

--- a/system-ml/src/main/java/com/ibm/bi/dml/runtime/util/LocalFileUtils.java
+++ b/system-ml/src/main/java/com/ibm/bi/dml/runtime/util/LocalFileUtils.java
@@ -37,10 +37,6 @@ import com.ibm.bi.dml.runtime.matrix.data.Pair;
 
 public class LocalFileUtils 
 {
-	@SuppressWarnings("unused")
-	private static final String _COPYRIGHT = "Licensed Materials - Property of IBM\n(C) Copyright IBM Corp. 2010, 2015\n" +
-	                                         "US Government Users Restricted Rights - Use, duplication  disclosure restricted by GSA ADP Schedule Contract with IBM Corp.";
-		
 	public static final int BUFFER_SIZE = 8192;
 	
 	//unique IDs per JVM for tmp files

--- a/system-ml/src/main/java/com/ibm/bi/dml/runtime/util/MapReduceTool.java
+++ b/system-ml/src/main/java/com/ibm/bi/dml/runtime/util/MapReduceTool.java
@@ -55,10 +55,6 @@ import com.ibm.bi.dml.runtime.matrix.sort.ReadWithZeros;
 
 public class MapReduceTool 
 {
-	@SuppressWarnings("unused")
-	private static final String _COPYRIGHT = "Licensed Materials - Property of IBM\n(C) Copyright IBM Corp. 2010, 2015\n" +
-	                                         "US Government Users Restricted Rights - Use, duplication  disclosure restricted by GSA ADP Schedule Contract with IBM Corp.";
-			
 	private static final Log LOG = LogFactory.getLog(MapReduceTool.class.getName());
 	private static JobConf _rJob = null; //cached job conf for read-only operations
 	

--- a/system-ml/src/main/java/com/ibm/bi/dml/runtime/util/NormalPRNGenerator.java
+++ b/system-ml/src/main/java/com/ibm/bi/dml/runtime/util/NormalPRNGenerator.java
@@ -29,10 +29,6 @@ import java.util.Random;
 
 public class NormalPRNGenerator extends PRNGenerator
 {
-	@SuppressWarnings("unused")
-	private static final String _COPYRIGHT = "Licensed Materials - Property of IBM\n(C) Copyright IBM Corp. 2010, 2013\n" +
-	                                         "US Government Users Restricted Rights - Use, duplication  disclosure restricted by GSA ADP Schedule Contract with IBM Corp.";
-		
 	//private long seed;
 	Random r;
 	private RandNPair pair;

--- a/system-ml/src/main/java/com/ibm/bi/dml/runtime/util/PoissonPRNGenerator.java
+++ b/system-ml/src/main/java/com/ibm/bi/dml/runtime/util/PoissonPRNGenerator.java
@@ -30,10 +30,6 @@ import org.apache.commons.math3.random.Well1024a;
 
 public class PoissonPRNGenerator extends PRNGenerator
 {
-	@SuppressWarnings("unused")
-	private static final String _COPYRIGHT = "Licensed Materials - Property of IBM\n(C) Copyright IBM Corp. 2010, 2013\n" +
-	                                         "US Government Users Restricted Rights - Use, duplication  disclosure restricted by GSA ADP Schedule Contract with IBM Corp.";
-		
 	PoissonDistribution _pdist = null;
 	double _mean = Double.NaN;
 	

--- a/system-ml/src/main/java/com/ibm/bi/dml/runtime/util/RandN.java
+++ b/system-ml/src/main/java/com/ibm/bi/dml/runtime/util/RandN.java
@@ -28,10 +28,6 @@ import java.util.Random;
 
 public class RandN 
 {
-	@SuppressWarnings("unused")
-	private static final String _COPYRIGHT = "Licensed Materials - Property of IBM\n(C) Copyright IBM Corp. 2010, 2013\n" +
-	                                         "US Government Users Restricted Rights - Use, duplication  disclosure restricted by GSA ADP Schedule Contract with IBM Corp.";
-		
 	//private long seed;
 	Random r;
 	private RandNPair pair;

--- a/system-ml/src/main/java/com/ibm/bi/dml/runtime/util/RandNPair.java
+++ b/system-ml/src/main/java/com/ibm/bi/dml/runtime/util/RandNPair.java
@@ -27,10 +27,6 @@ import java.util.Random;
 
 public class RandNPair 
 {
-	@SuppressWarnings("unused")
-	private static final String _COPYRIGHT = "Licensed Materials - Property of IBM\n(C) Copyright IBM Corp. 2010, 2013\n" +
-	                                         "US Government Users Restricted Rights - Use, duplication  disclosure restricted by GSA ADP Schedule Contract with IBM Corp.";
-		
 	private double N1, N2;
 	
 	public double getFirst() { return N1; }

--- a/system-ml/src/main/java/com/ibm/bi/dml/runtime/util/SortUtils.java
+++ b/system-ml/src/main/java/com/ibm/bi/dml/runtime/util/SortUtils.java
@@ -27,10 +27,6 @@ import com.ibm.bi.dml.runtime.controlprogram.parfor.stat.Timing;
  */
 public class SortUtils 
 {
-	@SuppressWarnings("unused")
-	private static final String _COPYRIGHT = "Licensed Materials - Property of IBM\n(C) Copyright IBM Corp. 2010, 2013\n" +
-	                                         "US Government Users Restricted Rights - Use, duplication  disclosure restricted by GSA ADP Schedule Contract with IBM Corp.";
-		
 	/**
 	 * 
 	 * @param start

--- a/system-ml/src/main/java/com/ibm/bi/dml/runtime/util/UtilFunctions.java
+++ b/system-ml/src/main/java/com/ibm/bi/dml/runtime/util/UtilFunctions.java
@@ -23,11 +23,6 @@ import com.ibm.bi.dml.runtime.matrix.mapred.IndexedMatrixValue;
 
 public class UtilFunctions 
 {
-	@SuppressWarnings("unused")
-	private static final String _COPYRIGHT = "Licensed Materials - Property of IBM\n(C) Copyright IBM Corp. 2010, 2015\n" +
-	                                         "US Government Users Restricted Rights - Use, duplication  disclosure restricted by GSA ADP Schedule Contract with IBM Corp.";
-		
-
 	//for accurate cast of double values to int and long 
 	//IEEE754: binary64 (double precision) eps = 2^(-53) = 1.11 * 10^(-16)
 	//(same epsilon as used for matrix index cast in R)

--- a/system-ml/src/test/java/com/ibm/bi/dml/test/integration/functions/recompile/CSVReadUnknownSizeTest.java
+++ b/system-ml/src/test/java/com/ibm/bi/dml/test/integration/functions/recompile/CSVReadUnknownSizeTest.java
@@ -34,9 +34,6 @@ import com.ibm.bi.dml.test.integration.TestConfiguration;
 import com.ibm.bi.dml.test.utils.TestUtils;
 
 public class CSVReadUnknownSizeTest extends AutomatedTestBase {
-	@SuppressWarnings("unused")
-	private static final String _COPYRIGHT = "Licensed Materials - Property of IBM\n(C) Copyright IBM Corp. 2010, 2015\n"
-			+ "US Government Users Restricted Rights - Use, duplication  disclosure restricted by GSA ADP Schedule Contract with IBM Corp.";
 
 	private final static String TEST_NAME = "csv_read_unknown";
 	private final static String TEST_DIR = "functions/recompile/";


### PR DESCRIPTION
Legacy _COPYRIGHT constants removed from 40 Java classes.