### PR TITLE
[SYSML-292] PyDML bool print with correct case

### DIFF
--- a/system-ml/src/main/java/com/ibm/bi/dml/api/DMLScript.java
+++ b/system-ml/src/main/java/com/ibm/bi/dml/api/DMLScript.java
@@ -60,6 +60,7 @@ import com.ibm.bi.dml.parser.DMLProgram;
 import com.ibm.bi.dml.parser.DMLTranslator;
 import com.ibm.bi.dml.parser.LanguageException;
 import com.ibm.bi.dml.parser.ParseException;
+import com.ibm.bi.dml.parser.ScriptType;
 import com.ibm.bi.dml.parser.antlr4.DMLParserWrapper;
 import com.ibm.bi.dml.parser.python.PyDMLParserWrapper;
 import com.ibm.bi.dml.runtime.DMLRuntimeException;
@@ -633,7 +634,7 @@ public class DMLScript
 			case HYBRID:
 			case SPARK:
 			case HYBRID_SPARK:
-				executeHadoop(dmlt, prog, conf, dmlScriptStr, allArgs);
+				executeHadoop(dmlt, prog, conf, dmlScriptStr, allArgs, parsePyDML);
 				break;
 				
 			default:
@@ -750,7 +751,7 @@ public class DMLScript
 	 * @throws DMLRuntimeException 
 	 * @throws DMLException 
 	 */
-	private static void executeHadoop(DMLTranslator dmlt, DMLProgram prog, DMLConfig conf, String dmlScriptStr, String[] allArgs) 
+	private static void executeHadoop(DMLTranslator dmlt, DMLProgram prog, DMLConfig conf, String dmlScriptStr, String[] allArgs, boolean parsePyDML) 
 		throws ParseException, IOException, LanguageException, HopsException, LopsException, DMLRuntimeException, DMLUnsupportedOperationException 
 	{	
 		LOG.debug("\n********************** OPTIMIZER *******************\n" + 
@@ -824,6 +825,11 @@ public class DMLScript
 			
 			//run execute (w/ exception handling to ensure proper shutdown)
 			ec = ExecutionContextFactory.createContext(rtprog);
+			if(parsePyDML) {
+				ec.setScriptType(ScriptType.PYDML);
+			} else {
+				ec.setScriptType(ScriptType.DML);
+			}
 			rtprog.execute( ec );  
 			
 		}

--- a/system-ml/src/main/java/com/ibm/bi/dml/hops/rewrite/ProgramRewriter.java
+++ b/system-ml/src/main/java/com/ibm/bi/dml/hops/rewrite/ProgramRewriter.java
@@ -37,6 +37,7 @@ import com.ibm.bi.dml.parser.ParForStatementBlock;
 import com.ibm.bi.dml.parser.StatementBlock;
 import com.ibm.bi.dml.parser.WhileStatement;
 import com.ibm.bi.dml.parser.WhileStatementBlock;
+import com.ibm.bi.dml.parser.ScriptType;
 
 /**
  * This program rewriter applies a variety of rule-based rewrites
@@ -51,6 +52,7 @@ public class ProgramRewriter
 	
 	private ArrayList<HopRewriteRule> _dagRuleSet = null;
 	private ArrayList<StatementBlockRewriteRule> _sbRuleSet = null;
+	private ScriptType _scriptType = null;
 	
 	static{
 		// for internal debugging only
@@ -268,6 +270,9 @@ public class ProgramRewriter
 		for( HopRewriteRule r : _dagRuleSet )
 		{
 			Hop.resetVisitStatus( roots ); //reset for each rule
+			if (r instanceof RewriteConstantFolding) {
+				((RewriteConstantFolding) r).setProgramRewriter(this);
+			}
 			roots = r.rewriteHopDAGs(roots, state);
 		}
 		
@@ -378,5 +383,13 @@ public class ProgramRewriter
 		}
 		
 		return ret;
+	}
+
+	public ScriptType getScriptType() {
+		return _scriptType;
+	}
+
+	public void setScriptType(ScriptType scriptType) {
+		this._scriptType = scriptType;
 	}
 }

--- a/system-ml/src/main/java/com/ibm/bi/dml/parser/DMLProgram.java
+++ b/system-ml/src/main/java/com/ibm/bi/dml/parser/DMLProgram.java
@@ -56,6 +56,8 @@ public class DMLProgram
 	private HashMap<String,DMLProgram> _namespaces;
 	public static String DEFAULT_NAMESPACE = ".defaultNS";
 	public static String INTERNAL_NAMESPACE = "_internal"; // used for multi-return builtin functions
+	private ScriptType _scriptType = null;
+	
 	private static final Log LOG = LogFactory.getLog(DMLProgram.class.getName());
 	
 	public DMLProgram(){
@@ -177,6 +179,7 @@ public class DMLProgram
 		
 		// constructor resets the set of registered functions
 		Program rtprog = new Program();
+		rtprog.setScriptType(_scriptType);
 		
 		// for all namespaces, translate function statement blocks into function program blocks
 		for (String namespace : _namespaces.keySet()){
@@ -779,5 +782,14 @@ public class DMLProgram
 	{
 		return fkey.split(Program.KEY_DELIM);
 	}
+
+	public ScriptType getScriptType() {
+		return _scriptType;
+	}
+
+	public void setScriptType(ScriptType scriptType) {
+		this._scriptType = scriptType;
+	}
+
 }
 

--- a/system-ml/src/main/java/com/ibm/bi/dml/parser/DMLTranslator.java
+++ b/system-ml/src/main/java/com/ibm/bi/dml/parser/DMLTranslator.java
@@ -268,6 +268,7 @@ public class DMLTranslator
 	{
 		//apply hop rewrites (static rewrites)
 		ProgramRewriter rewriter = new ProgramRewriter(true, false);
+		rewriter.setScriptType(dmlp.getScriptType());
 		rewriter.rewriteProgramHopDAGs(dmlp);
 		resetHopsDAGVisitStatus(dmlp);
 		

--- a/system-ml/src/main/java/com/ibm/bi/dml/parser/ScriptType.java
+++ b/system-ml/src/main/java/com/ibm/bi/dml/parser/ScriptType.java
@@ -1,0 +1,9 @@
+package com.ibm.bi.dml.parser;
+
+public enum ScriptType {
+	DML, PYDML;
+	
+	public String lowerCase() {
+		return super.toString().toLowerCase();
+	}
+}

--- a/system-ml/src/main/java/com/ibm/bi/dml/parser/antlr4/DMLParserWrapper.java
+++ b/system-ml/src/main/java/com/ibm/bi/dml/parser/antlr4/DMLParserWrapper.java
@@ -26,6 +26,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.HashMap;
 import java.util.Map;
+
 import org.antlr.v4.runtime.BailErrorStrategy;
 import org.antlr.v4.runtime.DefaultErrorStrategy;
 import org.antlr.v4.runtime.atn.PredictionMode;
@@ -49,6 +50,7 @@ import com.ibm.bi.dml.parser.LanguageException;
 import com.ibm.bi.dml.parser.ParForStatement;
 import com.ibm.bi.dml.parser.ParForStatementBlock;
 import com.ibm.bi.dml.parser.ParseException;
+import com.ibm.bi.dml.parser.ScriptType;
 import com.ibm.bi.dml.parser.Statement;
 import com.ibm.bi.dml.parser.StatementBlock;
 import com.ibm.bi.dml.parser.WhileStatement;
@@ -140,6 +142,7 @@ public class DMLParserWrapper {
 		if(prog == null) {
 			throw new ParseException("One or more errors found during parsing (could not construct AST for file: " + fileName + "). Cannot proceed ahead.");
 		}
+		prog.setScriptType(ScriptType.DML);
 		return prog;
 	}
 

--- a/system-ml/src/main/java/com/ibm/bi/dml/parser/python/PyDMLParserWrapper.java
+++ b/system-ml/src/main/java/com/ibm/bi/dml/parser/python/PyDMLParserWrapper.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
+
 import org.antlr.v4.runtime.ANTLRInputStream;
 import org.antlr.v4.runtime.BailErrorStrategy;
 import org.antlr.v4.runtime.CommonTokenStream;
@@ -55,6 +56,7 @@ import com.ibm.bi.dml.parser.python.PydmlParser.FunctionStatementContext;
 import com.ibm.bi.dml.parser.python.PydmlParser.PmlprogramContext;
 import com.ibm.bi.dml.parser.python.PydmlParser.StatementContext;
 import com.ibm.bi.dml.parser.python.PydmlSyntacticErrorListener.CustomDmlErrorListener;
+import com.ibm.bi.dml.parser.ScriptType;
 
 /**
  * Logic of this wrapper is similar to DMLParserWrapper.
@@ -119,6 +121,7 @@ public class PyDMLParserWrapper {
 		if(prog == null) {
 			throw new ParseException("One or more errors found during parsing. (could not construct AST for file: " + fileName + "). Cannot proceed ahead.");
 		}
+		prog.setScriptType(ScriptType.PYDML);
 		return prog;
 	}
 

--- a/system-ml/src/main/java/com/ibm/bi/dml/runtime/controlprogram/Program.java
+++ b/system-ml/src/main/java/com/ibm/bi/dml/runtime/controlprogram/Program.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.Map.Entry;
 
 import com.ibm.bi.dml.parser.DMLProgram;
+import com.ibm.bi.dml.parser.ScriptType;
 import com.ibm.bi.dml.runtime.DMLRuntimeException;
 import com.ibm.bi.dml.runtime.DMLScriptException;
 import com.ibm.bi.dml.runtime.DMLUnsupportedOperationException;
@@ -34,8 +35,8 @@ public class Program
 	public static final String KEY_DELIM = "::";
 	
 	public ArrayList<ProgramBlock> _programBlocks;
-
 	private HashMap<String, HashMap<String,FunctionProgramBlock>> _namespaceFunctions;
+	private ScriptType _scriptType = null;
 	
 	public Program() throws DMLRuntimeException {
 		_namespaceFunctions = new HashMap<String, HashMap<String,FunctionProgramBlock>>(); 
@@ -161,4 +162,13 @@ public class Program
 			pb.printMe();
 		}
 	}
+
+	public ScriptType getScriptType() {
+		return _scriptType;
+	}
+
+	public void setScriptType(ScriptType scriptType) {
+		this._scriptType = scriptType;
+	}
+	
 }

--- a/system-ml/src/main/java/com/ibm/bi/dml/runtime/controlprogram/context/ExecutionContext.java
+++ b/system-ml/src/main/java/com/ibm/bi/dml/runtime/controlprogram/context/ExecutionContext.java
@@ -27,6 +27,7 @@ import com.ibm.bi.dml.debug.DMLProgramCounter;
 import com.ibm.bi.dml.debug.DebugState;
 import com.ibm.bi.dml.parser.DMLProgram;
 import com.ibm.bi.dml.parser.Expression.ValueType;
+import com.ibm.bi.dml.parser.ScriptType;
 import com.ibm.bi.dml.runtime.DMLRuntimeException;
 import com.ibm.bi.dml.runtime.controlprogram.LocalVariableMap;
 import com.ibm.bi.dml.runtime.controlprogram.Program;
@@ -59,6 +60,9 @@ public class ExecutionContext
 	
 	//debugging (optional)
 	protected DebugState _dbState = null;
+	
+	// DML or PyDML
+	protected ScriptType _scriptType = null;
 	
 	protected ExecutionContext()
 	{
@@ -519,4 +523,19 @@ public class ExecutionContext
 		_dbState.prevPC.setProgramBlockNumber(_dbState.getPC().getProgramBlockNumber());
 		_dbState.prevPC.setLineNumber(currInst.getLineNum());
 	}
+
+	public ScriptType getScriptType() {
+		if (_scriptType != null) {
+			return _scriptType;
+		} else if (_prog != null) {
+			return _prog.getScriptType();
+		} else {
+			return null;
+		}
+	}
+
+	public void setScriptType(ScriptType scriptType) {
+		this._scriptType = scriptType;
+	}
+	
 }

--- a/system-ml/src/main/java/com/ibm/bi/dml/runtime/instructions/cp/ScalarBuiltinCPInstruction.java
+++ b/system-ml/src/main/java/com/ibm/bi/dml/runtime/instructions/cp/ScalarBuiltinCPInstruction.java
@@ -19,11 +19,13 @@ package com.ibm.bi.dml.runtime.instructions.cp;
 
 import com.ibm.bi.dml.api.DMLScript;
 import com.ibm.bi.dml.parser.Expression.ValueType;
+import com.ibm.bi.dml.parser.ScriptType;
 import com.ibm.bi.dml.runtime.DMLRuntimeException;
 import com.ibm.bi.dml.runtime.DMLScriptException;
 import com.ibm.bi.dml.runtime.controlprogram.context.ExecutionContext;
 import com.ibm.bi.dml.runtime.matrix.operators.Operator;
 import com.ibm.bi.dml.runtime.matrix.operators.SimpleOperator;
+import com.ibm.bi.dml.utils.PyDMLUtils;
 
 
 public class ScalarBuiltinCPInstruction extends BuiltinUnaryCPInstruction
@@ -49,6 +51,11 @@ public class ScalarBuiltinCPInstruction extends BuiltinUnaryCPInstruction
 		//core execution
 		if ( opcode.equalsIgnoreCase("print") ) {
 			String outString = so.getStringValue();
+			
+			// Handle PyDML boolean case (True/False)
+			if ((so instanceof BooleanObject) && (ec.getScriptType() == ScriptType.PYDML)) {
+				outString = PyDMLUtils.convertBooleanStringToPyDMLBooleanString(outString);
+			}
 			
 			// print to stdout only when suppress flag in DMLScript is not set.
 			// The flag will be set, for example, when SystemML is invoked in fenced mode from Jaql.

--- a/system-ml/src/main/java/com/ibm/bi/dml/runtime/instructions/cp/ScalarScalarArithmeticCPInstruction.java
+++ b/system-ml/src/main/java/com/ibm/bi/dml/runtime/instructions/cp/ScalarScalarArithmeticCPInstruction.java
@@ -18,12 +18,14 @@
 package com.ibm.bi.dml.runtime.instructions.cp;
 
 import com.ibm.bi.dml.parser.Expression.ValueType;
+import com.ibm.bi.dml.parser.ScriptType;
 import com.ibm.bi.dml.runtime.DMLRuntimeException;
 import com.ibm.bi.dml.runtime.controlprogram.context.ExecutionContext;
 import com.ibm.bi.dml.runtime.functionobjects.Divide;
 import com.ibm.bi.dml.runtime.functionobjects.Power;
 import com.ibm.bi.dml.runtime.matrix.operators.BinaryOperator;
 import com.ibm.bi.dml.runtime.matrix.operators.Operator;
+import com.ibm.bi.dml.utils.PyDMLUtils;
 
 
 public class ScalarScalarArithmeticCPInstruction extends ArithmeticBinaryCPInstruction
@@ -55,6 +57,21 @@ public class ScalarScalarArithmeticCPInstruction extends ArithmeticBinaryCPInstr
 			//pre-check (for robustness regarding too long strings)
 			String val1 = so1.getStringValue();
 			String val2 = so2.getStringValue();
+			
+			// Handle PyDML boolean case (True/False)
+			ScriptType scriptType = ec.getScriptType();
+			if ((scriptType != null) && (scriptType == ScriptType.PYDML)) {
+				if (input1.getValueType() == ValueType.BOOLEAN) {
+					val1 = PyDMLUtils.convertBooleanStringToPyDMLBooleanString(so1.getStringValue());
+				} else if (input2.getValueType() == ValueType.BOOLEAN) {
+					val2 = PyDMLUtils.convertBooleanStringToPyDMLBooleanString(so2.getStringValue());
+				} else if (so1.getValueType() == ValueType.BOOLEAN) { // input1 valueType is a string but actually a boolean
+					val1 = PyDMLUtils.convertBooleanStringToPyDMLBooleanString(so1.getStringValue());
+				} else if (so2.getValueType() == ValueType.BOOLEAN) { // input2 valueType is a string but actually a boolean
+					val2 = PyDMLUtils.convertBooleanStringToPyDMLBooleanString(so2.getStringValue());
+				}
+			}
+			
 			StringObject.checkMaxStringLength(val1.length() + val2.length());
 			
 			String rval = dop.fn.execute(val1, val2);

--- a/system-ml/src/main/java/com/ibm/bi/dml/utils/PyDMLUtils.java
+++ b/system-ml/src/main/java/com/ibm/bi/dml/utils/PyDMLUtils.java
@@ -1,0 +1,17 @@
+package com.ibm.bi.dml.utils;
+
+import org.apache.commons.lang.StringUtils;
+
+public class PyDMLUtils {
+
+	/**
+	 * Typically, converts String TRUE/FALSE to String True/False
+	 * 
+	 * @param val
+	 *            Original boolean String value
+	 * @return Converted boolean String value
+	 */
+	public static String convertBooleanStringToPyDMLBooleanString(String val) {
+		return StringUtils.capitalize(StringUtils.lowerCase(val));
+	}
+}


### PR DESCRIPTION
Previously, if a PyDML bool was printed, it would appear as TRUE/FALSE rather than True/False, even though bool values need to be specified as True/False in PyDML. An awareness of the script type needs to be passed down to the level where it is needed in order to generate case-correct output. Boolean case conversions were added to ScalarBuiltinCPInstruction, ArithmeticBinaryCPInstruction, and RewriteConstantFolding via a PyDMLUtils.convertBooleanStringToPyDMLBooleanString() method. Additional code modifications were made to pass the ScriptType awareness where necessary so that it could be placed in an ExecutionContext for access. The ScriptType is set on the ExecutionContext object via a setter method in RewriteConstantFolding so that it has the flexibility to correctly handle setting the script type in cases such as if a PyDML test runs after a DML test.