### PR TITLE
[SYSML-330] [WIP] MLContext no error if read or write input argument

### DIFF
--- a/system-ml/src/main/java/com/ibm/bi/dml/api/MLContext.java
+++ b/system-ml/src/main/java/com/ibm/bi/dml/api/MLContext.java
@@ -1190,7 +1190,7 @@ public class MLContext {
 		_rtprog = null;
 		
 		//parsing
-		AParserWrapper parser = AParserWrapper.createParser(parsePyDML);
+		AParserWrapper parser = AParserWrapper.createParser(parsePyDML, true);
 		DMLProgram prog = parser.parse(dmlScriptFilePath, dmlScriptStr, argVals);
 		if(prog == null) {
 			throw new ParseException("Couldnot parse the file:" + dmlScriptFilePath);

--- a/system-ml/src/main/java/com/ibm/bi/dml/parser/AParserWrapper.java
+++ b/system-ml/src/main/java/com/ibm/bi/dml/parser/AParserWrapper.java
@@ -28,6 +28,8 @@ import com.ibm.bi.dml.parser.python.PyDMLParserWrapper;
  */
 public abstract class AParserWrapper 
 {
+	private boolean mlContext; // Is invocation from MLContext?	
+	
 	/**
 	 * 
 	 * @param fileName
@@ -41,13 +43,13 @@ public abstract class AParserWrapper
 	
 	
 	/**
-	 * Factory method for creating instances of AParserWrapper, for
-	 * simplificy fused with the abstract class.
+	 * Factory method for creating instances of AParserWrapper.
 	 * 
-	 * @param pydml
+	 * @param pydml Is PyDML being parsed?
+	 * @param mlContext Is SystemML being invoked from MLContext? 
 	 * @return
 	 */
-	public static AParserWrapper createParser(boolean pydml)
+	public static AParserWrapper createParser(boolean pydml, boolean mlContext)
 	{
 		AParserWrapper ret = null;
 		
@@ -56,7 +58,27 @@ public abstract class AParserWrapper
 			ret = new PyDMLParserWrapper();
 		else
 			ret = new DMLParserWrapper();
-		
+		ret.mlContext = mlContext;
 		return ret;
 	}
+	
+	/**
+	 * Create a DML or PyDML parser wrapper that is not invoked from MLContext
+	 * 
+	 * @param pydml
+	 * @return
+	 */
+	public static AParserWrapper createParser(boolean pydml) {
+		return createParser(pydml, false);
+	}
+
+	/**
+	 * 
+	 * @return Whether or not SystemML is being invoked from MLContext
+	 */
+	public boolean isMlContext() {
+		return mlContext;
+	}
+	
+	
 }

--- a/system-ml/src/main/java/com/ibm/bi/dml/parser/antlr4/DMLParserWrapper.java
+++ b/system-ml/src/main/java/com/ibm/bi/dml/parser/antlr4/DMLParserWrapper.java
@@ -139,8 +139,7 @@ public class DMLParserWrapper extends AParserWrapper
 		}
 		
 		// Set the pipeline required for ANTLR parsing
-		DMLParserWrapper parser = new DMLParserWrapper();
-		prog = parser.doParse(fileName, dmlScript, argVals);
+		prog = doParse(fileName, dmlScript, argVals);
 		
 		if(prog == null) {
 			throw new ParseException("One or more errors found during parsing (could not construct AST for file: " + fileName + "). Cannot proceed ahead.");
@@ -238,7 +237,7 @@ public class DMLParserWrapper extends AParserWrapper
 			// And also do syntactic validation
 			org.antlr.v4.runtime.tree.ParseTreeWalker walker = new ParseTreeWalker();
 			DmlSyntacticValidatorHelper helper = new DmlSyntacticValidatorHelper(errorListener);
-			DmlSyntacticValidator validator = new DmlSyntacticValidator(helper, errorListener.peekFileName(), argVals);
+			DmlSyntacticValidator validator = new DmlSyntacticValidator(helper, errorListener.peekFileName(), argVals, isMlContext());
 			walker.walk(validator, tree);
 			errorListener.popFileName();
 			if(errorListener.isAtleastOneError()) {

--- a/system-ml/src/main/java/com/ibm/bi/dml/parser/python/PyDMLParserWrapper.java
+++ b/system-ml/src/main/java/com/ibm/bi/dml/parser/python/PyDMLParserWrapper.java
@@ -116,8 +116,7 @@ public class PyDMLParserWrapper extends AParserWrapper
 		}
 		
 		// Set the pipeline required for ANTLR parsing
-		PyDMLParserWrapper parser = new PyDMLParserWrapper();
-		prog = parser.doParse(fileName, dmlScript, argVals);
+		prog = doParse(fileName, dmlScript, argVals);
 		
 		if(prog == null) {
 			throw new ParseException("One or more errors found during parsing. (could not construct AST for file: " + fileName + "). Cannot proceed ahead.");
@@ -213,7 +212,7 @@ public class PyDMLParserWrapper extends AParserWrapper
 			// And also do syntactic validation
 			ParseTreeWalker walker = new ParseTreeWalker();
 			PydmlSyntacticValidatorHelper helper = new PydmlSyntacticValidatorHelper(errorListener);
-			PydmlSyntacticValidator validator = new PydmlSyntacticValidator(helper, fileName, argVals);
+			PydmlSyntacticValidator validator = new PydmlSyntacticValidator(helper, fileName, argVals, isMlContext());
 			walker.walk(validator, tree);
 			errorListener.popFileName();
 			if(errorListener.isAtleastOneError()) {


### PR DESCRIPTION
Fix so that no error is thrown if MLContext invokes a DML or PyDML script that has read/write/load/save statements with input arguments.