### PR TITLE
[SYSML-347] Invocation Tabs on Algorithms Reference

### DIFF
--- a/system-ml/docs/algorithms-bibliography.md
+++ b/system-ml/docs/algorithms-bibliography.md
@@ -6,103 +6,103 @@ displayTitle: <a href="algorithms-reference.html">SystemML Algorithms Reference<
 
 # 7. Bibliography
 
-AcockStavig1979, Alan C. Acock and Gordon
+**[AcockStavig1979]** Alan C. Acock and Gordon
 R. Stavig, A Measure of Association for Nonparametric
 Statistics, Social Forces, Oxford University
 Press, Volume 57, Number 4, June, 1979,
 1381--1386.
 
-AgrawalKSX2002, Rakesh Agrawal and
+**[AgrawalKSX2002]** Rakesh Agrawal and
 Jerry Kiernan and Ramakrishnan Srikant and Yirong Xu,
 Hippocratic Databases, Proceedings of the 28-th
 International Conference on Very Large Data Bases (VLDB 2002),
 Hong Kong, China, August 20--23, 2002,
 143--154.
 
-Agresti2002, Alan Agresti, Categorical
+**[Agresti2002]** Alan Agresti, Categorical
 Data Analysis, Second Edition, Wiley Series in
 Probability and Statistics, Wiley-Interscience
 2002, 710.
 
-AloiseDHP2009, Daniel Aloise and Amit
+**[AloiseDHP2009]** Daniel Aloise and Amit
 Deshpande and Pierre Hansen and Preyas Popat, NP-hardness of
 Euclidean Sum-of-squares Clustering, Machine Learning,
 Kluwer Academic Publishers, Volume 75, Number 2,
 May, 2009, 245--248.
 
-ArthurVassilvitskii2007,
+**[ArthurVassilvitskii2007]**
 k-means++: The Advantages of Careful Seeding, David
 Arthur and Sergei Vassilvitskii, Proceedings of the 18th
 Annual ACM-SIAM Symposium on Discrete Algorithms (SODA 2007),
 January 7--9, 2007, New Orleans, LA,
 USA, 1027--1035.
 
-Breiman2001, L. Breiman. Random forests. Machine Learning, 45(1):5–32, 2001.
+**[Breiman2001]** L. Breiman. Random forests. Machine Learning, 45(1):5–32, 2001.
 
-BreimanFOS1984, L. Breiman, J. H. Friedman, R. A. Olshen, and C. J. Stone. Classification and Regression Trees. Wadsworth, 1984.
+**[BreimanFOS1984]** L. Breiman, J. H. Friedman, R. A. Olshen, and C. J. Stone. Classification and Regression Trees. Wadsworth, 1984.
 
-Chapelle2007, Olivier Chapelle, Training a Support Vector Machine in the Primal, Neural Computation, 2007.
+**[Chapelle2007]** Olivier Chapelle, Training a Support Vector Machine in the Primal, Neural Computation, 2007.
 
-Cochran1954, William G. Cochran,
+**[Cochran1954]** William G. Cochran,
 Some Methods for Strengthening the Common $\chi^2$ Tests, 
 Biometrics, Volume 10, Number 4, December
 1954, 417--451.
 
-Collett2003, D. Collett. Modelling Survival Data in Medical Research, Second Edition. Chapman & Hall/CRC Texts in Statistical Science. Taylor & Francis, 2003.
+**[Collett2003]** D. Collett. Modelling Survival Data in Medical Research, Second Edition. Chapman & Hall/CRC Texts in Statistical Science. Taylor & Francis, 2003.
 
-Gill2000, Jeff Gill, Generalized Linear
+**[Gill2000]** Jeff Gill, Generalized Linear
 Models: A Unified Approach, Sage University Papers Series on
 Quantitative Applications in the Social Sciences, Number 07-134,
 2000, Sage Publications, 101.
 
-Hartigan1975, John A. Hartigan,
+**[Hartigan1975]** John A. Hartigan,
 Clustering Algorithms, John Wiley~&~Sons Inc.,
 Probability and Mathematical Statistics, April
 1975, 365.
 
-Hsieh2008, C-J Hsieh, K-W Chang, C-J Lin, S. S. Keerthi and S. Sundararajan, A Dual Coordinate Descent Method for Large-scale Linear SVM, International Conference of Machine Learning (ICML), 2008.
+**[Hsieh2008]** C-J Hsieh, K-W Chang, C-J Lin, S. S. Keerthi and S. Sundararajan, A Dual Coordinate Descent Method for Large-scale Linear SVM, International Conference of Machine Learning (ICML), 2008.
 
-Lin2008, Chih-Jen Lin and Ruby C. Weng and
+**[Lin2008]** Chih-Jen Lin and Ruby C. Weng and
 S. Sathiya Keerthi, Trust Region Newton Method for
 Large-Scale Logistic Regression, Journal of Machine Learning
 Research, April, 2008, Volume 9, 627--650.
 
-McCallum1998, A. McCallum and K. Nigam, A comparison of event models for naive bayes text classification, AAAI-98 workshop on learning for text categorization, 1998.
+**[McCallum1998]** A. McCallum and K. Nigam, A comparison of event models for naive bayes text classification, AAAI-98 workshop on learning for text categorization, 1998.
 
-McCullagh1989, Peter McCullagh and John Ashworth
+**[McCullagh1989]** Peter McCullagh and John Ashworth
 Nelder, Generalized Linear Models, Second Edition,
 Monographs on Statistics and Applied Probability, Number 37,
 1989, Chapman & Hall/CRC, 532.
 
-Nelder1972, John Ashworth Nelder and Robert
+**[Nelder1972]** John Ashworth Nelder and Robert
 William Maclagan Wedderburn, Generalized Linear Models,
 Journal of the Royal Statistical Society, Series A
 (General), 1972, Volume 135, Number 3, 
 370--384.
 
-Nocedal1999, J. Nocedal and S. J. Wright, Numerical Optimization, Springer-Verlag, 1999.
+**[Nocedal1999]** J. Nocedal and S. J. Wright, Numerical Optimization, Springer-Verlag, 1999.
 
-Nocedal2006, Optimization Numerical Optimization,
+**[Nocedal2006]** Optimization Numerical Optimization,
 Jorge Nocedal and Stephen Wright, Springer Series
 in Operations Research and Financial Engineering, 664,
 Second Edition, Springer, 2006.
 
-PandaHBB2009, B. Panda, J. Herbach, S. Basu, and R. J. Bayardo. PLANET: massively parallel learning of tree ensembles with mapreduce. PVLDB, 2(2):1426– 1437, 2009.
+**[PandaHBB2009]** B. Panda, J. Herbach, S. Basu, and R. J. Bayardo. PLANET: massively parallel learning of tree ensembles with mapreduce. PVLDB, 2(2):1426– 1437, 2009.
 
-Russell2009, S. Russell and P. Norvig, Artificial Intelligence: A Modern Approach, Prentice Hall, 2009.
+**[Russell2009]** S. Russell and P. Norvig, Artificial Intelligence: A Modern Approach, Prentice Hall, 2009.
 
-Scholkopf1995, B. Scholkopf, C. Burges and V. Vapnik, Extracting Support Data for a Given Task, International Conference on Knowledge Discovery and Data Mining (ICDM), 1995.
+**[Scholkopf1995]** B. Scholkopf, C. Burges and V. Vapnik, Extracting Support Data for a Given Task, International Conference on Knowledge Discovery and Data Mining (ICDM), 1995.
 
-Stevens1946, Stanley Smith Stevens,
+**[Stevens1946]** Stanley Smith Stevens,
 On the Theory of Scales of Measurement, Science
 June 7, 1946, Volume 103, Number 2684, 
 677--680.
 
-Vetterling1992,
+**[Vetterling1992]**
 W. T. Vetterling and B. P. Flannery,
 Multidimensions in Numerical Recipes in C - The Art in Scientific Computing, W. H. Press and S. A. Teukolsky (eds.), Cambridge University Press, 1992.
 
-ZhouWSP08,
+**[ZhouWSP08]**
 Y. Zhou, D. M. Wilkinson, R. Schreiber, and R. Pan. Large-scale parallel collaborative filtering for the Netflix prize.
 In Algorithmic Aspects in Information and Management, 4th International Conference, AAIM 2008, Shanghai, China, June 23-25, 2008. Proceedings, pages 337–348, 2008.
 

--- a/system-ml/docs/algorithms-classification.md
+++ b/system-ml/docs/algorithms-classification.md
@@ -108,6 +108,8 @@ Eqs. (1) and (2).
 
 ### Usage
 
+<div class="codetabs">
+<div data-lang="Hadoop" markdown="1">
     hadoop jar SystemML.jar -f MultiLogReg.dml
                             -nvargs X=<file>
                                     Y=<file>
@@ -119,7 +121,27 @@ Eqs. (1) and (2).
                                     moi=[int]
                                     mii=[int]
                                     fmt=[format]
-
+</div>
+<div data-lang="Spark" markdown="1">
+    $SPARK_HOME/bin/spark-submit --master yarn-cluster
+                                 --conf spark.driver.maxResultSize=0
+                                 --conf spark.akka.frameSize=128
+                                 SystemML.jar
+                                 -f MultiLogReg.dml
+                                 -config=SystemML-config.xml
+                                 -exec hybrid_spark
+                                 -nvargs X=<file>
+                                         Y=<file>
+                                         B=<file>
+                                         Log=[file]
+                                         icpt=[int]
+                                         reg=[double]
+                                         tol=[double]
+                                         moi=[int]
+                                         mii=[int]
+                                         fmt=[format]
+</div>
+</div>
 
 ### Arguments
 
@@ -173,6 +195,8 @@ SystemML Language Reference for details.
 
 ### Examples
 
+<div class="codetabs">
+<div data-lang="Hadoop" markdown="1">
     hadoop jar SystemML.jar -f MultiLogReg.dml
                             -nvargs X=/user/ml/X.mtx
                                     Y=/user/ml/Y.mtx
@@ -184,6 +208,27 @@ SystemML Language Reference for details.
                                     moi=100
                                     mii=10
                                     Log=/user/ml/log.csv
+</div>
+<div data-lang="Spark" markdown="1">
+    $SPARK_HOME/bin/spark-submit --master yarn-cluster
+                                 --conf spark.driver.maxResultSize=0
+                                 --conf spark.akka.frameSize=128
+                                 SystemML.jar
+                                 -f MultiLogReg.dml
+                                 -config=SystemML-config.xml
+                                 -exec hybrid_spark
+                                 -nvargs X=/user/ml/X.mtx
+                                         Y=/user/ml/Y.mtx
+                                         B=/user/ml/B.mtx
+                                         fmt=csv
+                                         icpt=2
+                                         reg=1.0
+                                         tol=0.0001
+                                         moi=100
+                                         mii=10
+                                         Log=/user/ml/log.csv
+</div>
+</div>
 
 
 * * *
@@ -329,6 +374,8 @@ support vector machine (`y` with domain size `2`).
 
 **Binary-Class Support Vector Machines**:
 
+<div class="codetabs">
+<div data-lang="Hadoop" markdown="1">
     hadoop jar SystemML.jar -f l2-svm.dml
                             -nvargs X=<file>
                                     Y=<file>
@@ -339,9 +386,31 @@ support vector machine (`y` with domain size `2`).
                                     model=<file>
                                     Log=<file>
                                     fmt=[format]
+</div>
+<div data-lang="Spark" markdown="1">
+    $SPARK_HOME/bin/spark-submit --master yarn-cluster
+                                 --conf spark.driver.maxResultSize=0
+                                 --conf spark.akka.frameSize=128
+                                 SystemML.jar
+                                 -f l2-svm.dml
+                                 -config=SystemML-config.xml
+                                 -exec hybrid_spark
+                                 -nvargs X=<file>
+                                         Y=<file>
+                                         icpt=[int]
+                                         tol=[double]
+                                         reg=[double]
+                                         maxiter=[int]
+                                         model=<file>
+                                         Log=<file>
+                                         fmt=[format]
+</div>
+</div>
 
 **Binary-Class Support Vector Machines Prediction**:
 
+<div class="codetabs">
+<div data-lang="Hadoop" markdown="1">
     hadoop jar SystemML.jar -f l2-svm-predict.dml
                             -nvargs X=<file>
                                     Y=[file]
@@ -351,7 +420,25 @@ support vector machine (`y` with domain size `2`).
                                     accuracy=[file]
                                     confusion=[file]
                                     fmt=[format]
-
+</div>
+<div data-lang="Spark" markdown="1">
+    $SPARK_HOME/bin/spark-submit --master yarn-cluster
+                                 --conf spark.driver.maxResultSize=0
+                                 --conf spark.akka.frameSize=128
+                                 SystemML.jar
+                                 -f l2-svm-predict.dml
+                                 -config=SystemML-config.xml
+                                 -exec hybrid_spark
+                                 -nvargs X=<file>
+                                         Y=[file]
+                                         icpt=[int]
+                                         model=<file>
+                                         scores=[file]
+                                         accuracy=[file]
+                                         confusion=[file]
+                                         fmt=[format]
+</div>
+</div>
 
 #### Arguments
 
@@ -403,6 +490,8 @@ using a held-out test set. Note that this is an optional argument.
 
 **Binary-Class Support Vector Machines**:
 
+<div class="codetabs">
+<div data-lang="Hadoop" markdown="1">
     hadoop jar SystemML.jar -f l2-svm.dml
                             -nvargs X=/user/ml/X.mtx
                                     Y=/user/ml/y.mtx
@@ -413,9 +502,31 @@ using a held-out test set. Note that this is an optional argument.
                                     maxiter=100
                                     model=/user/ml/weights.csv
                                     Log=/user/ml/Log.csv
+</div>
+<div data-lang="Spark" markdown="1">
+    $SPARK_HOME/bin/spark-submit --master yarn-cluster
+                                 --conf spark.driver.maxResultSize=0
+                                 --conf spark.akka.frameSize=128
+                                 SystemML.jar
+                                 -f l2-svm.dml
+                                 -config=SystemML-config.xml
+                                 -exec hybrid_spark
+                                 -nvargs X=/user/ml/X.mtx
+                                         Y=/user/ml/y.mtx
+                                         icpt=0
+                                         tol=0.001
+                                         fmt=csv
+                                         reg=1.0
+                                         maxiter=100
+                                         model=/user/ml/weights.csv
+                                         Log=/user/ml/Log.csv
+</div>
+</div>
 
 **Binary-Class Support Vector Machines Prediction**:
 
+<div class="codetabs">
+<div data-lang="Hadoop" markdown="1">
     hadoop jar SystemML.jar -f l2-svm-predict.dml
                             -nvargs X=/user/ml/X.mtx
                                     Y=/user/ml/y.mtx
@@ -425,6 +536,25 @@ using a held-out test set. Note that this is an optional argument.
                                     scores=/user/ml/scores.csv
                                     accuracy=/user/ml/accuracy.csv
                                     confusion=/user/ml/confusion.csv
+</div>
+<div data-lang="Spark" markdown="1">
+    $SPARK_HOME/bin/spark-submit --master yarn-cluster
+                                 --conf spark.driver.maxResultSize=0
+                                 --conf spark.akka.frameSize=128
+                                 SystemML.jar
+                                 -f l2-svm-predict.dml
+                                 -config=SystemML-config.xml
+                                 -exec hybrid_spark
+                                 -nvargs X=/user/ml/X.mtx
+                                         Y=/user/ml/y.mtx
+                                         icpt=0
+                                         fmt=csv
+                                         model=/user/ml/weights.csv
+                                         scores=/user/ml/scores.csv
+                                         accuracy=/user/ml/accuracy.csv
+                                         confusion=/user/ml/confusion.csv
+</div>
+</div>
 
 
 #### Details
@@ -481,6 +611,8 @@ class labels.
 
 **Multi-Class Support Vector Machines**:
 
+<div class="codetabs">
+<div data-lang="Hadoop" markdown="1">
     hadoop jar SystemML.jar -f m-svm.dml
                             -nvargs X=<file>
                                     Y=<file>
@@ -491,9 +623,31 @@ class labels.
                                     model=<file>
                                     Log=<file>
                                     fmt=[format]
+</div>
+<div data-lang="Spark" markdown="1">
+    $SPARK_HOME/bin/spark-submit --master yarn-cluster
+                                 --conf spark.driver.maxResultSize=0
+                                 --conf spark.akka.frameSize=128
+                                 SystemML.jar
+                                 -f m-svm.dml
+                                 -config=SystemML-config.xml
+                                 -exec hybrid_spark
+                                 -nvargs X=<file>
+                                         Y=<file>
+                                         icpt=[int]
+                                         tol=[double]
+                                         reg=[double]
+                                         maxiter=[int]
+                                         model=<file>
+                                         Log=<file>
+                                         fmt=[format]
+</div>
+</div>
 
 **Multi-Class Support Vector Machines Prediction**:
 
+<div class="codetabs">
+<div data-lang="Hadoop" markdown="1">
     hadoop jar SystemML.jar -f m-svm-predict.dml
                             -nvargs X=<file>
                                     Y=[file]
@@ -503,6 +657,25 @@ class labels.
                                     accuracy=[file]
                                     confusion=[file]
                                     fmt=[format]
+</div>
+<div data-lang="Spark" markdown="1">
+    $SPARK_HOME/bin/spark-submit --master yarn-cluster
+                                 --conf spark.driver.maxResultSize=0
+                                 --conf spark.akka.frameSize=128
+                                 SystemML.jar
+                                 -f m-svm-predict.dml
+                                 -config=SystemML-config.xml
+                                 -exec hybrid_spark
+                                 -nvargs X=<file>
+                                         Y=[file]
+                                         icpt=[int]
+                                         model=<file>
+                                         scores=[file]
+                                         accuracy=[file]
+                                         confusion=[file]
+                                         fmt=[format]
+</div>
+</div>
 
 
 #### Arguments
@@ -555,28 +728,71 @@ SystemML Language Reference for details.
 
 **Multi-Class Support Vector Machines**:
 
+<div class="codetabs">
+<div data-lang="Hadoop" markdown="1">
     hadoop jar SystemML.jar -f m-svm.dml
                             -nvargs X=/user/ml/X.mtx
-                                    Y=/user/ml/y.mtx 
+                                    Y=/user/ml/y.mtx
                                     icpt=0
                                     tol=0.001
-                                    reg=1.0 
-                                    maxiter=100 
-                                    fmt=csv 
+                                    reg=1.0
+                                    maxiter=100
+                                    fmt=csv
                                     model=/user/ml/weights.csv
                                     Log=/user/ml/Log.csv
+</div>
+<div data-lang="Spark" markdown="1">
+    $SPARK_HOME/bin/spark-submit --master yarn-cluster
+                                 --conf spark.driver.maxResultSize=0
+                                 --conf spark.akka.frameSize=128
+                                 SystemML.jar
+                                 -f m-svm.dml
+                                 -config=SystemML-config.xml
+                                 -exec hybrid_spark
+                                 -nvargs X=/user/ml/X.mtx
+                                         Y=/user/ml/y.mtx
+                                         icpt=0
+                                         tol=0.001
+                                         reg=1.0
+                                         maxiter=100
+                                         fmt=csv
+                                         model=/user/ml/weights.csv
+                                         Log=/user/ml/Log.csv
+</div>
+</div>
 
 **Multi-Class Support Vector Machines Prediction**:
 
-    hadoop jar SystemML.jar -f m-svm-predict.dml 
-                            -nvargs X=/user/ml/X.mtx 
-                                    Y=/user/ml/y.mtx 
-                                    icpt=0 
+<div class="codetabs">
+<div data-lang="Hadoop" markdown="1">
+    hadoop jar SystemML.jar -f m-svm-predict.dml
+                            -nvargs X=/user/ml/X.mtx
+                                    Y=/user/ml/y.mtx
+                                    icpt=0
                                     fmt=csv
                                     model=/user/ml/weights.csv
                                     scores=/user/ml/scores.csv
                                     accuracy=/user/ml/accuracy.csv
                                     confusion=/user/ml/confusion.csv
+</div>
+<div data-lang="Spark" markdown="1">
+    $SPARK_HOME/bin/spark-submit --master yarn-cluster
+                                 --conf spark.driver.maxResultSize=0
+                                 --conf spark.akka.frameSize=128
+                                 SystemML.jar
+                                 -f m-svm-predict.dml
+                                 -config=SystemML-config.xml
+                                 -exec hybrid_spark
+                                 -nvargs X=/user/ml/X.mtx
+                                         Y=/user/ml/y.mtx
+                                         icpt=0
+                                         fmt=csv
+                                         model=/user/ml/weights.csv
+                                         scores=/user/ml/scores.csv
+                                         accuracy=/user/ml/accuracy.csv
+                                         confusion=/user/ml/confusion.csv
+</div>
+</div>
 
 
 #### Details
@@ -636,6 +852,8 @@ applicable when all features are counts of categorical values.
 
 **Naive Bayes**:
 
+<div class="codetabs">
+<div data-lang="Hadoop" markdown="1">
     hadoop jar SystemML.jar -f naive-bayes.dml
                             -nvargs X=<file>
                                     Y=<file>
@@ -644,9 +862,29 @@ applicable when all features are counts of categorical values.
                                     conditionals=<file>
                                     accuracy=<file>
                                     fmt=[format]
+</div>
+<div data-lang="Spark" markdown="1">
+    $SPARK_HOME/bin/spark-submit --master yarn-cluster
+                                 --conf spark.driver.maxResultSize=0
+                                 --conf spark.akka.frameSize=128
+                                 SystemML.jar
+                                 -f naive-bayes.dml
+                                 -config=SystemML-config.xml
+                                 -exec hybrid_spark
+                                 -nvargs X=<file>
+                                         Y=<file>
+                                         laplace=[double]
+                                         prior=<file>
+                                         conditionals=<file>
+                                         accuracy=<file>
+                                         fmt=[format]
+</div>
+</div>
 
 **Naive Bayes Prediction**:
 
+<div class="codetabs">
+<div data-lang="Hadoop" markdown="1">
     hadoop jar SystemML.jar -f naive-bayes-predict.dml
                             -nvargs X=<file>
                                     Y=[file]
@@ -656,6 +894,25 @@ applicable when all features are counts of categorical values.
                                     accuracy=[file]
                                     confusion=[file]
                                     probabilities=[file]
+</div>
+<div data-lang="Spark" markdown="1">
+    $SPARK_HOME/bin/spark-submit --master yarn-cluster
+                                 --conf spark.driver.maxResultSize=0
+                                 --conf spark.akka.frameSize=128
+                                 SystemML.jar
+                                 -f naive-bayes-predict.dml
+                                 -config=SystemML-config.xml
+                                 -exec hybrid_spark
+                                 -nvargs X=<file>
+                                         Y=[file]
+                                         prior=<file>
+                                         conditionals=<file>
+                                         fmt=[format]
+                                         accuracy=[file]
+                                         confusion=[file]
+                                         probabilities=[file]
+</div>
+</div>
 
 
 ### Arguments
@@ -698,25 +955,67 @@ SystemML Language Reference for details.
 
 **Naive Bayes**:
 
+<div class="codetabs">
+<div data-lang="Hadoop" markdown="1">
     hadoop jar SystemML.jar -f naive-bayes.dml
-                            -nvargs X=/user/ml/X.mtx 
-                                    Y=/user/ml/y.mtx 
-                                    laplace=1 fmt=csv
+                            -nvargs X=/user/ml/X.mtx
+                                    Y=/user/ml/y.mtx
+                                    laplace=1
+                                    fmt=csv
                                     prior=/user/ml/prior.csv
                                     conditionals=/user/ml/conditionals.csv
                                     accuracy=/user/ml/accuracy.csv
+</div>
+<div data-lang="Spark" markdown="1">
+    $SPARK_HOME/bin/spark-submit --master yarn-cluster
+                                 --conf spark.driver.maxResultSize=0
+                                 --conf spark.akka.frameSize=128
+                                 SystemML.jar
+                                 -f naive-bayes.dml
+                                 -config=SystemML-config.xml
+                                 -exec hybrid_spark
+                                 -nvargs X=/user/ml/X.mtx
+                                         Y=/user/ml/y.mtx
+                                         laplace=1
+                                         fmt=csv
+                                         prior=/user/ml/prior.csv
+                                         conditionals=/user/ml/conditionals.csv
+                                         accuracy=/user/ml/accuracy.csv
+</div>
+</div>
 
 **Naive Bayes Prediction**:
 
+<div class="codetabs">
+<div data-lang="Hadoop" markdown="1">
     hadoop jar SystemML.jar -f naive-bayes-predict.dml
-                            -nvargs X=/user/ml/X.mtx 
-                                    Y=/user/ml/y.mtx 
+                            -nvargs X=/user/ml/X.mtx
+                                    Y=/user/ml/y.mtx
                                     prior=/user/ml/prior.csv
                                     conditionals=/user/ml/conditionals.csv
                                     fmt=csv
                                     accuracy=/user/ml/accuracy.csv
                                     probabilities=/user/ml/probabilities.csv
                                     confusion=/user/ml/confusion.csv
+</div>
+<div data-lang="Spark" markdown="1">
+    $SPARK_HOME/bin/spark-submit --master yarn-cluster
+                                 --conf spark.driver.maxResultSize=0
+                                 --conf spark.akka.frameSize=128
+                                 SystemML.jar
+                                 -f naive-bayes-predict.dml
+                                 -config=SystemML-config.xml
+                                 -exec hybrid_spark
+                                 -nvargs X=/user/ml/X.mtx
+                                         Y=/user/ml/y.mtx
+                                         prior=/user/ml/prior.csv
+                                         conditionals=/user/ml/conditionals.csv
+                                         fmt=csv
+                                         accuracy=/user/ml/accuracy.csv
+                                         probabilities=/user/ml/probabilities.csv
+                                         confusion=/user/ml/confusion.csv
+</div>
+</div>
 
 
 ### Details
@@ -781,6 +1080,8 @@ implementation is well-suited to handle large-scale data and builds a
 
 **Decision Tree**:
 
+<div class="codetabs">
+<div data-lang="Hadoop" markdown="1">
     hadoop jar SystemML.jar -f decision-tree.dml
                             -nvargs X=<file>
                                     Y=<file>
@@ -795,9 +1096,35 @@ implementation is well-suited to handle large-scale data and builds a
                                     S_map=[file]
                                     C_map=[file]
                                     fmt=[format]
+</div>
+<div data-lang="Spark" markdown="1">
+    $SPARK_HOME/bin/spark-submit --master yarn-cluster
+                                 --conf spark.driver.maxResultSize=0
+                                 --conf spark.akka.frameSize=128
+                                 SystemML.jar
+                                 -f decision-tree.dml
+                                 -config=SystemML-config.xml
+                                 -exec hybrid_spark
+                                 -nvargs X=<file>
+                                         Y=<file>
+                                         R=[file]
+                                         M=<file>
+                                         bins=[int]
+                                         depth=[int]
+                                         num_leaf=[int]
+                                         num_samples=[int]
+                                         impurity=[Gini|entropy]
+                                         O=[file]
+                                         S_map=[file]
+                                         C_map=[file]
+                                         fmt=[format]
+</div>
+</div>
 
 **Decision Tree Prediction**:
 
+<div class="codetabs">
+<div data-lang="Hadoop" markdown="1">
     hadoop jar SystemML.jar -f decision-tree-predict.dml
                             -nvargs X=<file>
                                     Y=[file]
@@ -807,6 +1134,25 @@ implementation is well-suited to handle large-scale data and builds a
                                     A=[file]
                                     CM=[file]
                                     fmt=[format]
+</div>
+<div data-lang="Spark" markdown="1">
+    $SPARK_HOME/bin/spark-submit --master yarn-cluster
+                                 --conf spark.driver.maxResultSize=0
+                                 --conf spark.akka.frameSize=128
+                                 SystemML.jar
+                                 -f decision-tree-predict.dml
+                                 -config=SystemML-config.xml
+                                 -exec hybrid_spark
+                                 -nvargs X=<file>
+                                         Y=[file]
+                                         R=[file]
+                                         M=<file>
+                                         P=<file>
+                                         A=[file]
+                                         CM=[file]
+                                         fmt=[format]
+</div>
+</div>
 
 
 ### Arguments
@@ -875,6 +1221,8 @@ SystemML Language Reference for details.
 
 **Decision Tree**:
 
+<div class="codetabs">
+<div data-lang="Hadoop" markdown="1">
     hadoop jar SystemML.jar -f decision-tree.dml
                             -nvargs X=/user/ml/X.mtx
                                     Y=/user/ml/Y.mtx
@@ -886,9 +1234,32 @@ SystemML Language Reference for details.
                                     num_samples=3000
                                     impurity=Gini
                                     fmt=csv
+</div>
+<div data-lang="Spark" markdown="1">
+    $SPARK_HOME/bin/spark-submit --master yarn-cluster
+                                 --conf spark.driver.maxResultSize=0
+                                 --conf spark.akka.frameSize=128
+                                 SystemML.jar
+                                 -f decision-tree.dml
+                                 -config=SystemML-config.xml
+                                 -exec hybrid_spark
+                                 -nvargs X=/user/ml/X.mtx
+                                         Y=/user/ml/Y.mtx
+                                         R=/user/ml/R.csv
+                                         M=/user/ml/model.csv
+                                         bins=20
+                                         depth=25
+                                         num_leaf=10
+                                         num_samples=3000
+                                         impurity=Gini
+                                         fmt=csv
+</div>
+</div>
 
 **Decision Tree Prediction**:
 
+<div class="codetabs">
+<div data-lang="Hadoop" markdown="1">
     hadoop jar SystemML.jar -f decision-tree-predict.dml
                             -nvargs X=/user/ml/X.mtx
                                     Y=/user/ml/Y.mtx
@@ -898,7 +1269,25 @@ SystemML Language Reference for details.
                                     A=/user/ml/accuracy.csv
                                     CM=/user/ml/confusion.csv
                                     fmt=csv
-                                    
+</div>
+<div data-lang="Spark" markdown="1">
+    $SPARK_HOME/bin/spark-submit --master yarn-cluster
+                                 --conf spark.driver.maxResultSize=0
+                                 --conf spark.akka.frameSize=128
+                                 SystemML.jar
+                                 -f decision-tree-predict.dml
+                                 -config=SystemML-config.xml
+                                 -exec hybrid_spark
+                                 -nvargs X=/user/ml/X.mtx
+                                         Y=/user/ml/Y.mtx
+                                         R=/user/ml/R.csv
+                                         M=/user/ml/model.csv
+                                         P=/user/ml/predictions.csv
+                                         A=/user/ml/accuracy.csv
+                                         CM=/user/ml/confusion.csv
+                                         fmt=csv
+</div>
+</div>
 
 
 ### Details
@@ -1096,6 +1485,8 @@ for classification in parallel.
 
 **Random Forest**:
 
+<div class="codetabs">
+<div data-lang="Hadoop" markdown="1">
     hadoop jar SystemML.jar -f random-forest.dml
                             -nvargs X=<file>
                                     Y=<file>
@@ -1113,9 +1504,38 @@ for classification in parallel.
                                     S_map=[file]
                                     C_map=[file]
                                     fmt=[format]
+</div>
+<div data-lang="Spark" markdown="1">
+    $SPARK_HOME/bin/spark-submit --master yarn-cluster
+                                 --conf spark.driver.maxResultSize=0
+                                 --conf spark.akka.frameSize=128
+                                 SystemML.jar
+                                 -f random-forest.dml
+                                 -config=SystemML-config.xml
+                                 -exec hybrid_spark
+                                 -nvargs X=<file>
+                                         Y=<file>
+                                         R=[file]
+                                         M=<file>
+                                         bins=[int]
+                                         depth=[int]
+                                         num_leaf=[int]
+                                         num_samples=[int]
+                                         num_trees=[int]
+                                         subsamp_rate=[double]
+                                         feature_subset=[double]
+                                         impurity=[Gini|entropy]
+                                         C=[file]
+                                         S_map=[file]
+                                         C_map=[file]
+                                         fmt=[format]
+</div>
+</div>
 
 **Random Forest Prediction**:
 
+<div class="codetabs">
+<div data-lang="Hadoop" markdown="1">
     hadoop jar SystemML.jar -f random-forest-predict.dml
                             -nvargs X=<file>
                                     Y=[file]
@@ -1127,6 +1547,27 @@ for classification in parallel.
                                     OOB=[file]
                                     CM=[file]
                                     fmt=[format]
+</div>
+<div data-lang="Spark" markdown="1">
+    $SPARK_HOME/bin/spark-submit --master yarn-cluster
+                                 --conf spark.driver.maxResultSize=0
+                                 --conf spark.akka.frameSize=128
+                                 SystemML.jar
+                                 -f random-forest-predict.dml
+                                 -config=SystemML-config.xml
+                                 -exec hybrid_spark
+                                 -nvargs X=<file>
+                                         Y=[file]
+                                         R=[file]
+                                         M=<file>
+                                         C=[file]
+                                         P=<file>
+                                         A=[file]
+                                         OOB=[file]
+                                         CM=[file]
+                                         fmt=[format]
+</div>
+</div>
 
 
 ### Arguments
@@ -1215,6 +1656,8 @@ SystemML Language Reference for details.
 
 **Random Forest**:
 
+<div class="codetabs">
+<div data-lang="Hadoop" markdown="1">
     hadoop jar SystemML.jar -f random-forest.dml
                             -nvargs X=/user/ml/X.mtx
                                     Y=/user/ml/Y.mtx
@@ -1227,11 +1670,35 @@ SystemML Language Reference for details.
                                     num_trees=10
                                     impurity=Gini
                                     fmt=csv
+</div>
+<div data-lang="Spark" markdown="1">
+    $SPARK_HOME/bin/spark-submit --master yarn-cluster
+                                 --conf spark.driver.maxResultSize=0
+                                 --conf spark.akka.frameSize=128
+                                 SystemML.jar
+                                 -f random-forest.dml
+                                 -config=SystemML-config.xml
+                                 -exec hybrid_spark
+                                 -nvargs X=/user/ml/X.mtx
+                                         Y=/user/ml/Y.mtx
+                                         R=/user/ml/R.csv
+                                         M=/user/ml/model.csv
+                                         bins=20
+                                         depth=25
+                                         num_leaf=10
+                                         num_samples=3000
+                                         num_trees=10
+                                         impurity=Gini
+                                         fmt=csv
+</div>
+</div>
 
 **Random Forest Prediction**:
 
 To compute predictions:
 
+<div class="codetabs">
+<div data-lang="Hadoop" markdown="1">
     hadoop jar SystemML.jar -f random-forest-predict.dml
                             -nvargs X=/user/ml/X.mtx
                                     Y=/user/ml/Y.mtx
@@ -1241,6 +1708,25 @@ To compute predictions:
                                     A=/user/ml/accuracy.csv
                                     CM=/user/ml/confusion.csv
                                     fmt=csv
+</div>
+<div data-lang="Spark" markdown="1">
+    $SPARK_HOME/bin/spark-submit --master yarn-cluster
+                                 --conf spark.driver.maxResultSize=0
+                                 --conf spark.akka.frameSize=128
+                                 SystemML.jar
+                                 -f random-forest-predict.dml
+                                 -config=SystemML-config.xml
+                                 -exec hybrid_spark
+                                 -nvargs X=/user/ml/X.mtx
+                                         Y=/user/ml/Y.mtx
+                                         R=/user/ml/R.csv
+                                         M=/user/ml/model.csv
+                                         P=/user/ml/predictions.csv
+                                         A=/user/ml/accuracy.csv
+                                         CM=/user/ml/confusion.csv
+                                         fmt=csv
+</div>
+</div>
 
 
 ### Details

--- a/system-ml/docs/algorithms-clustering.md
+++ b/system-ml/docs/algorithms-clustering.md
@@ -95,6 +95,8 @@ apart is a “false negative” etc.
 
 **K-Means**:
 
+<div class="codetabs">
+<div data-lang="Hadoop" markdown="1">
     hadoop jar SystemML.jar -f Kmeans.dml
                             -nvargs X=<file>
                                     C=[file]
@@ -107,9 +109,33 @@ apart is a “false negative” etc.
                                     Y=[file]
                                     fmt=[format]
                                     verb=[int]
+</div>
+<div data-lang="Spark" markdown="1">
+    $SPARK_HOME/bin/spark-submit --master yarn-cluster
+                                 --conf spark.driver.maxResultSize=0
+                                 --conf spark.akka.frameSize=128
+                                 SystemML.jar
+                                 -f Kmeans.dml
+                                 -config=SystemML-config.xml
+                                 -exec hybrid_spark
+                                 -nvargs X=<file>
+                                         C=[file]
+                                         k=<int>
+                                         runs=[int]
+                                         maxi=[int]
+                                         tol=[double]
+                                         samp=[int]
+                                         isY=[int]
+                                         Y=[file]
+                                         fmt=[format]
+                                         verb=[int]
+</div>
+</div>
 
 **K-Means Prediction**:
 
+<div class="codetabs">
+<div data-lang="Hadoop" markdown="1">
     hadoop jar SystemML.jar -f Kmeans-predict.dml
                             -nvargs X=[file]
                                     C=[file]
@@ -117,7 +143,23 @@ apart is a “false negative” etc.
                                     prY=[file]
                                     fmt=[format]
                                     O=[file]
-
+</div>
+<div data-lang="Spark" markdown="1">
+    $SPARK_HOME/bin/spark-submit --master yarn-cluster
+                                 --conf spark.driver.maxResultSize=0
+                                 --conf spark.akka.frameSize=128
+                                 SystemML.jar
+                                 -f Kmeans-predict.dml
+                                 -config=SystemML-config.xml
+                                 -exec hybrid_spark
+                                 -nvargs X=[file]
+                                         C=[file]
+                                         spY=[file]
+                                         prY=[file]
+                                         fmt=[format]
+                                         O=[file]
+</div>
+</div>
 
 
 ### Arguments - K-Means
@@ -186,12 +228,31 @@ standard output
 
 **K-Means**:
 
+<div class="codetabs">
+<div data-lang="Hadoop" markdown="1">
     hadoop jar SystemML.jar -f Kmeans.dml
                             -nvargs X=/user/ml/X.mtx
                                     k=5
                                     C=/user/ml/centroids.mtx
                                     fmt=csv
+</div>
+<div data-lang="Spark" markdown="1">
+    $SPARK_HOME/bin/spark-submit --master yarn-cluster
+                                 --conf spark.driver.maxResultSize=0
+                                 --conf spark.akka.frameSize=128
+                                 SystemML.jar
+                                 -f Kmeans.dml
+                                 -config=SystemML-config.xml
+                                 -exec hybrid_spark
+                                 -nvargs X=/user/ml/X.mtx
+                                         k=5
+                                         C=/user/ml/centroids.mtx
+                                         fmt=csv
+</div>
+</div>
 
+<div class="codetabs">
+<div data-lang="Hadoop" markdown="1">
     hadoop jar SystemML.jar -f Kmeans.dml
                             -nvargs X=/user/ml/X.mtx
                                     k=5
@@ -203,33 +264,104 @@ standard output
                                     isY=1
                                     Y=/user/ml/Yout.mtx
                                     verb=1
+</div>
+<div data-lang="Spark" markdown="1">
+    $SPARK_HOME/bin/spark-submit --master yarn-cluster
+                                 --conf spark.driver.maxResultSize=0
+                                 --conf spark.akka.frameSize=128
+                                 SystemML.jar
+                                 -f Kmeans.dml
+                                 -config=SystemML-config.xml
+                                 -exec hybrid_spark
+                                 -nvargs X=/user/ml/X.mtx
+                                         k=5
+                                         runs=100
+                                         maxi=5000
+                                         tol=0.00000001
+                                         samp=20
+                                         C=/user/ml/centroids.mtx
+                                         isY=1
+                                         Y=/user/ml/Yout.mtx
+                                         verb=1
+</div>
+</div>
 
 **K-Means Prediction**:
 
 To predict Y given X and C:
 
+<div class="codetabs">
+<div data-lang="Hadoop" markdown="1">
     hadoop jar SystemML.jar -f Kmeans-predict.dml
                             -nvargs X=/user/ml/X.mtx
                                     C=/user/ml/C.mtx
                                     prY=/user/ml/PredY.mtx
                                     O=/user/ml/stats.csv
+</div>
+<div data-lang="Spark" markdown="1">
+    $SPARK_HOME/bin/spark-submit --master yarn-cluster
+                                 --conf spark.driver.maxResultSize=0
+                                 --conf spark.akka.frameSize=128
+                                 SystemML.jar
+                                 -f Kmeans-predict.dml
+                                 -config=SystemML-config.xml
+                                 -exec hybrid_spark
+                                 -nvargs X=/user/ml/X.mtx
+                                         C=/user/ml/C.mtx
+                                         prY=/user/ml/PredY.mtx
+                                         O=/user/ml/stats.csv
+</div>
+</div>
 
 To compare “actual” labels `spY` with “predicted” labels
 given X and C:
 
+<div class="codetabs">
+<div data-lang="Hadoop" markdown="1">
     hadoop jar SystemML.jar -f Kmeans-predict.dml
                             -nvargs X=/user/ml/X.mtx
                                     C=/user/ml/C.mtx
                                     spY=/user/ml/Y.mtx
                                     O=/user/ml/stats.csv
+</div>
+<div data-lang="Spark" markdown="1">
+    $SPARK_HOME/bin/spark-submit --master yarn-cluster
+                                 --conf spark.driver.maxResultSize=0
+                                 --conf spark.akka.frameSize=128
+                                 SystemML.jar
+                                 -f Kmeans-predict.dml
+                                 -config=SystemML-config.xml
+                                 -exec hybrid_spark
+                                 -nvargs X=/user/ml/X.mtx
+                                         C=/user/ml/C.mtx
+                                         spY=/user/ml/Y.mtx
+                                         O=/user/ml/stats.csv
+</div>
+</div>
 
 To compare “actual” labels `spY` with given “predicted”
 labels prY:
 
+<div class="codetabs">
+<div data-lang="Hadoop" markdown="1">
     hadoop jar SystemML.jar -f Kmeans-predict.dml
                             -nvargs spY=/user/ml/Y.mtx
                                     prY=/user/ml/PredY.mtx
                                     O=/user/ml/stats.csv
+</div>
+<div data-lang="Spark" markdown="1">
+    $SPARK_HOME/bin/spark-submit --master yarn-cluster
+                                 --conf spark.driver.maxResultSize=0
+                                 --conf spark.akka.frameSize=128
+                                 SystemML.jar
+                                 -f Kmeans-predict.dml
+                                 -config=SystemML-config.xml
+                                 -exec hybrid_spark
+                                 -nvargs spY=/user/ml/Y.mtx
+                                         prY=/user/ml/PredY.mtx
+                                         O=/user/ml/stats.csv
+</div>
+</div>
 
 
 * * *

--- a/system-ml/docs/algorithms-descriptive-statistics.md
+++ b/system-ml/docs/algorithms-descriptive-statistics.md
@@ -99,10 +99,26 @@ to compute the mean of a categorical attribute like ‘Hair Color’.
 
 ### Usage
 
+<div class="codetabs">
+<div data-lang="Hadoop" markdown="1">
     hadoop jar SystemML.jar -f Univar-Stats.dml
-                            -nvargs X=<file> 
+                            -nvargs X=<file>
                                     TYPES=<file>
                                     STATS=<file>
+</div>
+<div data-lang="Spark" markdown="1">
+    $SPARK_HOME/bin/spark-submit --master yarn-cluster
+                                 --conf spark.driver.maxResultSize=0
+                                 --conf spark.akka.frameSize=128
+                                 SystemML.jar
+                                 -f Univar-Stats.dml
+                                 -config=SystemML-config.xml
+                                 -exec hybrid_spark
+                                 -nvargs X=<file>
+                                         TYPES=<file>
+                                         STATS=<file>
+</div>
+</div>
 
 
 ### Arguments
@@ -122,10 +138,26 @@ be stored. The format of the output matrix is defined by
 
 ### Examples
 
+<div class="codetabs">
+<div data-lang="Hadoop" markdown="1">
     hadoop jar SystemML.jar -f Univar-Stats.dml
                             -nvargs X=/user/ml/X.mtx
                                     TYPES=/user/ml/types.mtx
                                     STATS=/user/ml/stats.mtx
+</div>
+<div data-lang="Spark" markdown="1">
+    $SPARK_HOME/bin/spark-submit --master yarn-cluster
+                                 --conf spark.driver.maxResultSize=0
+                                 --conf spark.akka.frameSize=128
+                                 SystemML.jar
+                                 -f Univar-Stats.dml
+                                 -config=SystemML-config.xml
+                                 -exec hybrid_spark
+                                 -nvargs X=/user/ml/X.mtx
+                                         TYPES=/user/ml/types.mtx
+                                         STATS=/user/ml/stats.mtx
+</div>
+</div>
 
 
 * * *
@@ -524,6 +556,8 @@ attributes like ‘Hair Color’.
 
 ### Usage
 
+<div class="codetabs">
+<div data-lang="Hadoop" markdown="1">
     hadoop jar SystemML.jar -f bivar-stats.dml
                             -nvargs X=<file>
                                     index1=<file>
@@ -531,6 +565,23 @@ attributes like ‘Hair Color’.
                                     types1=<file>
                                     types2=<file>
                                     OUTDIR=<directory>
+</div>
+<div data-lang="Spark" markdown="1">
+    $SPARK_HOME/bin/spark-submit --master yarn-cluster
+                                 --conf spark.driver.maxResultSize=0
+                                 --conf spark.akka.frameSize=128
+                                 SystemML.jar
+                                 -f bivar-stats.dml
+                                 -config=SystemML-config.xml
+                                 -exec hybrid_spark
+                                 -nvargs X=<file>
+                                         index1=<file>
+                                         index2=<file>
+                                         types1=<file>
+                                         types2=<file>
+                                         OUTDIR=<directory>
+</div>
+</div>
 
 
 ### Arguments
@@ -574,6 +625,8 @@ are defined in [**Table 2**](algorithms-descriptive-statistics.html#table2).
 
 ### Examples
 
+<div class="codetabs">
+<div data-lang="Hadoop" markdown="1">
     hadoop jar SystemML.jar -f bivar-stats.dml
                             -nvargs X=/user/ml/X.mtx
                                     index1=/user/ml/S1.mtx
@@ -581,7 +634,24 @@ are defined in [**Table 2**](algorithms-descriptive-statistics.html#table2).
                                     types1=/user/ml/K1.mtx
                                     types2=/user/ml/K2.mtx
                                     OUTDIR=/user/ml/stats.mtx
-    
+</div>
+<div data-lang="Spark" markdown="1">
+    $SPARK_HOME/bin/spark-submit --master yarn-cluster
+                                 --conf spark.driver.maxResultSize=0
+                                 --conf spark.akka.frameSize=128
+                                 SystemML.jar
+                                 -f bivar-stats.dml
+                                 -config=SystemML-config.xml
+                                 -exec hybrid_spark
+                                 -nvargs X=/user/ml/X.mtx
+                                         index1=/user/ml/S1.mtx
+                                         index2=/user/ml/S2.mtx
+                                         types1=/user/ml/K1.mtx
+                                         types2=/user/ml/K2.mtx
+                                         OUTDIR=/user/ml/stats.mtx
+</div>
+</div>
+
 
 * * *
 
@@ -1046,6 +1116,8 @@ becomes reversed and amplified (from $+0.1$ to $-0.5$) if we ignore the months.
 
 ### Usage
 
+<div class="codetabs">
+<div data-lang="Hadoop" markdown="1">
     hadoop jar SystemML.jar -f stratstats.dml
                             -nvargs X=<file>
                                     Xcid=[file]
@@ -1055,6 +1127,25 @@ becomes reversed and amplified (from $+0.1$ to $-0.5$) if we ignore the months.
                                     Scid=[int]
                                     O=<file>
                                     fmt=[format]
+</div>
+<div data-lang="Spark" markdown="1">
+    $SPARK_HOME/bin/spark-submit --master yarn-cluster
+                                 --conf spark.driver.maxResultSize=0
+                                 --conf spark.akka.frameSize=128
+                                 SystemML.jar
+                                 -f stratstats.dml
+                                 -config=SystemML-config.xml
+                                 -exec hybrid_spark
+                                 -nvargs X=<file>
+                                         Xcid=[file]
+                                         Y=[file]
+                                         Ycid=[file]
+                                         S=[file]
+                                         Scid=[int]
+                                         O=<file>
+                                         fmt=[format]
+</div>
+</div>
 
 
 ### Arguments
@@ -1233,21 +1324,61 @@ SystemML Language Reference for details.
 
 ### Examples
 
+<div class="codetabs">
+<div data-lang="Hadoop" markdown="1">
     hadoop jar SystemML.jar -f stratstats.dml
                             -nvargs X=/user/ml/X.mtx
                                     Xcid=/user/ml/Xcid.mtx
                                     Y=/user/ml/Y.mtx
                                     Ycid=/user/ml/Ycid.mtx
-                                    S=/user/ml/S.mtx Scid=2
+                                    S=/user/ml/S.mtx
+                                    Scid=2
                                     O=/user/ml/Out.mtx
                                     fmt=csv
+</div>
+<div data-lang="Spark" markdown="1">
+    $SPARK_HOME/bin/spark-submit --master yarn-cluster
+                                 --conf spark.driver.maxResultSize=0
+                                 --conf spark.akka.frameSize=128
+                                 SystemML.jar
+                                 -f stratstats.dml
+                                 -config=SystemML-config.xml
+                                 -exec hybrid_spark
+                                 -nvargs X=/user/ml/X.mtx
+                                         Xcid=/user/ml/Xcid.mtx
+                                         Y=/user/ml/Y.mtx
+                                         Ycid=/user/ml/Ycid.mtx
+                                         S=/user/ml/S.mtx
+                                         Scid=2
+                                         O=/user/ml/Out.mtx
+                                         fmt=csv
+</div>
+</div>
 
+<div class="codetabs">
+<div data-lang="Hadoop" markdown="1">
     hadoop jar SystemML.jar -f stratstats.dml
                             -nvargs X=/user/ml/Data.mtx
                                     Xcid=/user/ml/Xcid.mtx
                                     Ycid=/user/ml/Ycid.mtx
                                     Scid=7
                                     O=/user/ml/Out.mtx
+</div>
+<div data-lang="Spark" markdown="1">
+    $SPARK_HOME/bin/spark-submit --master yarn-cluster
+                                 --conf spark.driver.maxResultSize=0
+                                 --conf spark.akka.frameSize=128
+                                 SystemML.jar
+                                 -f stratstats.dml
+                                 -config=SystemML-config.xml
+                                 -exec hybrid_spark
+                                 -nvargs X=/user/ml/Data.mtx
+                                         Xcid=/user/ml/Xcid.mtx
+                                         Ycid=/user/ml/Ycid.mtx
+                                         Scid=7
+                                         O=/user/ml/Out.mtx
+</div>
+</div>
 
 
 ### Details

--- a/system-ml/docs/algorithms-matrix-factorization.md
+++ b/system-ml/docs/algorithms-matrix-factorization.md
@@ -25,6 +25,8 @@ top-$K$ (for a given value of $K$) principle components.
 
 ### Usage
 
+<div class="codetabs">
+<div data-lang="Hadoop" markdown="1">
     hadoop jar SystemML.jar -f PCA.dml
                             -nvargs INPUT=<file>
                                     K=<int>
@@ -34,6 +36,25 @@ top-$K$ (for a given value of $K$) principle components.
                                     OFMT=[format]
                                     MODEL=<file>
                                     OUTPUT=<file>
+</div>
+<div data-lang="Spark" markdown="1">
+    $SPARK_HOME/bin/spark-submit --master yarn-cluster
+                                 --conf spark.driver.maxResultSize=0
+                                 --conf spark.akka.frameSize=128
+                                 SystemML.jar
+                                 -f PCA.dml
+                                 -config=SystemML-config.xml
+                                 -exec hybrid_spark
+                                 -nvargs INPUT=<file>
+                                         K=<int>
+                                         CENTER=[int]
+                                         SCALE=[int]
+                                         PROJDATA=<int>
+                                         OFMT=[format]
+                                         MODEL=<file>
+                                         OUTPUT=<file>
+</div>
+</div>
 
 
 #### Arguments
@@ -66,9 +87,10 @@ SystemML Language Reference for details.
     vector space.
 
 
-
 #### Examples
 
+<div class="codetabs">
+<div data-lang="Hadoop" markdown="1">
     hadoop jar SystemML.jar -f PCA.dml 
                             -nvargs INPUT=/user/ml/input.mtx
                                     K=10
@@ -77,7 +99,27 @@ SystemML Language Reference for details.
                                     FMT=csv
                                     PROJDATA=1
                                     OUTPUT=/user/ml/pca_output/
+</div>
+<div data-lang="Spark" markdown="1">
+    $SPARK_HOME/bin/spark-submit --master yarn-cluster
+                                 --conf spark.driver.maxResultSize=0
+                                 --conf spark.akka.frameSize=128
+                                 SystemML.jar
+                                 -f PCA.dml
+                                 -config=SystemML-config.xml
+                                 -exec hybrid_spark
+                                 -nvargs INPUT=/user/ml/input.mtx
+                                         K=10
+                                         CENTER=1
+                                         SCALE=1O
+                                         FMT=csv
+                                         PROJDATA=1
+                                         OUTPUT=/user/ml/pca_output/
+</div>
+</div>
 
+<div class="codetabs">
+<div data-lang="Hadoop" markdown="1">
     hadoop jar SystemML.jar -f PCA.dml
                             -nvargs INPUT=/user/ml/test_input.mtx
                                     K=10
@@ -87,7 +129,25 @@ SystemML Language Reference for details.
                                     PROJDATA=1
                                     MODEL=/user/ml/pca_output/
                                     OUTPUT=/user/ml/test_output.mtx
-
+</div>
+<div data-lang="Spark" markdown="1">
+    $SPARK_HOME/bin/spark-submit --master yarn-cluster
+                                 --conf spark.driver.maxResultSize=0
+                                 --conf spark.akka.frameSize=128
+                                 SystemML.jar
+                                 -f PCA.dml
+                                 -config=SystemML-config.xml
+                                 -exec hybrid_spark
+                                 -nvargs INPUT=/user/ml/test_input.mtx
+                                         K=10
+                                         CENTER=1
+                                         SCALE=1O
+                                         FMT=csv
+                                         PROJDATA=1
+                                         MODEL=/user/ml/pca_output/
+                                         OUTPUT=/user/ml/test_output.mtx
+</div>
+</div>
 
 
 #### Details
@@ -164,6 +224,8 @@ problems.
 
 **ALS**:
 
+<div class="codetabs">
+<div data-lang="Hadoop" markdown="1">
     hadoop jar SystemML.jar -f ALS.dml
                             -nvargs V=<file>
                                     L=<file>
@@ -175,9 +237,32 @@ problems.
                                     check=[boolean]
                                     thr=[double]
                                     fmt=[format]
+</div>
+<div data-lang="Spark" markdown="1">
+    $SPARK_HOME/bin/spark-submit --master yarn-cluster
+                                 --conf spark.driver.maxResultSize=0
+                                 --conf spark.akka.frameSize=128
+                                 SystemML.jar
+                                 -f ALS.dml
+                                 -config=SystemML-config.xml
+                                 -exec hybrid_spark
+                                 -nvargs V=<file>
+                                         L=<file>
+                                         R=<file>
+                                         rank=[int]
+                                         reg=[L2|wL2]
+                                         lambda=[double]
+                                         maxi=[int]
+                                         check=[boolean]
+                                         thr=[double]
+                                         fmt=[format]
+</div>
+</div>
 
 **ALS Prediction**:
 
+<div class="codetabs">
+<div data-lang="Hadoop" markdown="1">
     hadoop jar SystemML.jar -f ALS_predict.dml
                             -nvargs X=<file>
                                     Y=<file>
@@ -186,9 +271,29 @@ problems.
                                     Vrows=<int>
                                     Vcols=<int>
                                     fmt=[format]
+</div>
+<div data-lang="Spark" markdown="1">
+    $SPARK_HOME/bin/spark-submit --master yarn-cluster
+                                 --conf spark.driver.maxResultSize=0
+                                 --conf spark.akka.frameSize=128
+                                 SystemML.jar
+                                 -f ALS_predict.dml
+                                 -config=SystemML-config.xml
+                                 -exec hybrid_spark
+                                 -nvargs X=<file>
+                                         Y=<file>
+                                         L=<file>
+                                         R=<file>
+                                         Vrows=<int>
+                                         Vcols=<int>
+                                         fmt=[format]
+</div>
+</div>
 
 **ALS Top-K Prediction**:
 
+<div class="codetabs">
+<div data-lang="Hadoop" markdown="1">
     hadoop jar SystemML.jar -f ALS_topk_predict.dml
                             -nvargs X=<file>
                                     Y=<file>
@@ -197,6 +302,24 @@ problems.
                                     V=<file>
                                     K=[int]
                                     fmt=[format]
+</div>
+<div data-lang="Spark" markdown="1">
+    $SPARK_HOME/bin/spark-submit --master yarn-cluster
+                                 --conf spark.driver.maxResultSize=0
+                                 --conf spark.akka.frameSize=128
+                                 SystemML.jar
+                                 -f ALS_topk_predict.dml
+                                 -config=SystemML-config.xml
+                                 -exec hybrid_spark
+                                 -nvargs X=<file>
+                                         Y=<file>
+                                         L=<file>
+                                         R=<file>
+                                         V=<file>
+                                         K=[int]
+                                         fmt=[format]
+</div>
+</div>
 
 
 ### Arguments - ALS
@@ -275,6 +398,8 @@ SystemML Language Reference for details.
 
 **ALS**:
 
+<div class="codetabs">
+<div data-lang="Hadoop" markdown="1">
     hadoop jar SystemML.jar -f ALS.dml
                             -nvargs V=/user/ml/V
                                     L=/user/ml/L
@@ -286,12 +411,34 @@ SystemML Language Reference for details.
                                     check=TRUE
                                     thr=0.001
                                     fmt=csv
-
+</div>
+<div data-lang="Spark" markdown="1">
+    $SPARK_HOME/bin/spark-submit --master yarn-cluster
+                                 --conf spark.driver.maxResultSize=0
+                                 --conf spark.akka.frameSize=128
+                                 SystemML.jar
+                                 -f ALS.dml
+                                 -config=SystemML-config.xml
+                                 -exec hybrid_spark
+                                 -nvargs V=/user/ml/V
+                                         L=/user/ml/L
+                                         R=/user/ml/R
+                                         rank=10
+                                         reg="wL"
+                                         lambda=0.0001
+                                         maxi=50
+                                         check=TRUE
+                                         thr=0.001
+                                         fmt=csv
+</div>
+</div>
 
 **ALS Prediction**:
 
 To compute predicted ratings for a given list of users and items:
 
+<div class="codetabs">
+<div data-lang="Hadoop" markdown="1">
     hadoop jar SystemML.jar -f ALS_predict.dml
                             -nvargs X=/user/ml/X
                                     Y=/user/ml/Y
@@ -300,13 +447,32 @@ To compute predicted ratings for a given list of users and items:
                                     Vrows=100000
                                     Vcols=10000
                                     fmt=csv
-
+</div>
+<div data-lang="Spark" markdown="1">
+    $SPARK_HOME/bin/spark-submit --master yarn-cluster
+                                 --conf spark.driver.maxResultSize=0
+                                 --conf spark.akka.frameSize=128
+                                 SystemML.jar
+                                 -f ALS_predict.dml
+                                 -config=SystemML-config.xml
+                                 -exec hybrid_spark
+                                 -nvargs X=/user/ml/X
+                                         Y=/user/ml/Y
+                                         L=/user/ml/L
+                                         R=/user/ml/R
+                                         Vrows=100000
+                                         Vcols=10000
+                                         fmt=csv
+</div>
+</div>
 
 **ALS Top-K Prediction**:
 
 To compute top-K items with highest predicted ratings together with the
 predicted ratings for a given list of users:
 
+<div class="codetabs">
+<div data-lang="Hadoop" markdown="1">
     hadoop jar SystemML.jar -f ALS_topk_predict.dml
                             -nvargs X=/user/ml/X
                                     Y=/user/ml/Y
@@ -315,6 +481,24 @@ predicted ratings for a given list of users:
                                     V=/user/ml/V
                                     K=10
                                     fmt=csv
+</div>
+<div data-lang="Spark" markdown="1">
+    $SPARK_HOME/bin/spark-submit --master yarn-cluster
+                                 --conf spark.driver.maxResultSize=0
+                                 --conf spark.akka.frameSize=128
+                                 SystemML.jar
+                                 -f ALS_topk_predict.dml
+                                 -config=SystemML-config.xml
+                                 -exec hybrid_spark
+                                 -nvargs X=/user/ml/X
+                                         Y=/user/ml/Y
+                                         L=/user/ml/L
+                                         R=/user/ml/R
+                                         V=/user/ml/V
+                                         K=10
+                                         fmt=csv
+</div>
+</div>
 
 
 ### Details

--- a/system-ml/docs/algorithms-regression.md
+++ b/system-ml/docs/algorithms-regression.md
@@ -61,6 +61,8 @@ efficient when the number of features $m$ is relatively small
 
 **Linear Regression - Direct Solve**:
 
+<div class="codetabs">
+<div data-lang="Hadoop" markdown="1">
     hadoop jar SystemML.jar -f LinearRegDS.dml
                             -nvargs X=<file>
                                     Y=<file>
@@ -69,10 +71,29 @@ efficient when the number of features $m$ is relatively small
                                     icpt=[int]
                                     reg=[double]
                                     fmt=[format]
-
+</div>
+<div data-lang="Spark" markdown="1">
+    $SPARK_HOME/bin/spark-submit --master yarn-cluster
+                                 --conf spark.driver.maxResultSize=0
+                                 --conf spark.akka.frameSize=128
+                                 SystemML.jar
+                                 -f LinearRegDS.dml
+                                 -config=SystemML-config.xml
+                                 -exec hybrid_spark
+                                 -nvargs X=<file>
+                                         Y=<file>
+                                         B=<file>
+                                         O=[file]
+                                         icpt=[int]
+                                         reg=[double]
+                                         fmt=[format]
+</div>
+</div>
 
 **Linear Regression - Conjugate Gradient**:
 
+<div class="codetabs">
+<div data-lang="Hadoop" markdown="1">
     hadoop jar SystemML.jar -f LinearRegCG.dml
                             -nvargs X=<file>
                                     Y=<file>
@@ -84,6 +105,27 @@ efficient when the number of features $m$ is relatively small
                                     tol=[double]
                                     maxi=[int]
                                     fmt=[format]
+</div>
+<div data-lang="Spark" markdown="1">
+    $SPARK_HOME/bin/spark-submit --master yarn-cluster
+                                 --conf spark.driver.maxResultSize=0
+                                 --conf spark.akka.frameSize=128
+                                 SystemML.jar
+                                 -f LinearRegCG.dml
+                                 -config=SystemML-config.xml
+                                 -exec hybrid_spark
+                                 -nvargs X=<file>
+                                         Y=<file>
+                                         B=<file>
+                                         O=[file]
+                                         Log=[file]
+                                         icpt=[int]
+                                         reg=[double]
+                                         tol=[double]
+                                         maxi=[int]
+                                         fmt=[format]
+</div>
+</div>
 
 
 ### Arguments
@@ -135,30 +177,71 @@ SystemML Language Reference for details.
 
 **Linear Regression - Direct Solve**:
 
+<div class="codetabs">
+<div data-lang="Hadoop" markdown="1">
     hadoop jar SystemML.jar -f LinearRegDS.dml
-                            -nvargs X=/user/ml/X.mtx 
-                                    Y=/user/ml/Y.mtx 
-                                    B=/user/ml/B.mtx 
-                                    fmt=csv 
-                                    O=/user/ml/stats.csv 
-                                    icpt=2 
+                            -nvargs X=/user/ml/X.mtx
+                                    Y=/user/ml/Y.mtx
+                                    B=/user/ml/B.mtx
+                                    fmt=csv
+                                    O=/user/ml/stats.csv
+                                    icpt=2
                                     reg=1.0
-
+</div>
+<div data-lang="Spark" markdown="1">
+    $SPARK_HOME/bin/spark-submit --master yarn-cluster
+                                 --conf spark.driver.maxResultSize=0
+                                 --conf spark.akka.frameSize=128
+                                 SystemML.jar
+                                 -f LinearRegDS.dml
+                                 -config=SystemML-config.xml
+                                 -exec hybrid_spark
+                                 -nvargs X=/user/ml/X.mtx
+                                         Y=/user/ml/Y.mtx
+                                         B=/user/ml/B.mtx
+                                         fmt=csv
+                                         O=/user/ml/stats.csv
+                                         icpt=2
+                                         reg=1.0
+</div>
+</div>
 
 **Linear Regression - Conjugate Gradient**:
 
+<div class="codetabs">
+<div data-lang="Hadoop" markdown="1">
     hadoop jar SystemML.jar -f LinearRegCG.dml
-                            -nvargs X=/user/ml/X.mtx 
-                                    Y=/user/ml/Y.mtx 
-                                    B=/user/ml/B.mtx 
-                                    fmt=csv 
-                                    O=/user/ml/stats.csv 
-                                    icpt=2 
-                                    reg=1.0 
-                                    tol=0.00000001 
-                                    maxi=100 
+                            -nvargs X=/user/ml/X.mtx
+                                    Y=/user/ml/Y.mtx
+                                    B=/user/ml/B.mtx
+                                    fmt=csv
+                                    O=/user/ml/stats.csv
+                                    icpt=2
+                                    reg=1.0
+                                    tol=0.00000001
+                                    maxi=100
                                     Log=/user/ml/log.csv
-
+</div>
+<div data-lang="Spark" markdown="1">
+    $SPARK_HOME/bin/spark-submit --master yarn-cluster
+                                 --conf spark.driver.maxResultSize=0
+                                 --conf spark.akka.frameSize=128
+                                 SystemML.jar
+                                 -f LinearRegCG.dml
+                                 -config=SystemML-config.xml
+                                 -exec hybrid_spark
+                                 -nvargs X=/user/ml/X.mtx
+                                         Y=/user/ml/Y.mtx
+                                         B=/user/ml/B.mtx
+                                         fmt=csv
+                                         O=/user/ml/stats.csv
+                                         icpt=2
+                                         reg=1.0
+                                         tol=0.00000001
+                                         maxi=100
+                                         Log=/user/ml/log.csv
+</div>
+</div>
 
 
 * * *
@@ -368,6 +451,8 @@ lowest AIC is computed.
 
 ### Usage
 
+<div class="codetabs">
+<div data-lang="Hadoop" markdown="1">
     hadoop jar SystemML.jar -f StepLinearRegDS.dml
                             -nvargs X=<file>
                                     Y=<file>
@@ -377,7 +462,25 @@ lowest AIC is computed.
                                     icpt=[int]
                                     thr=[double]
                                     fmt=[format]
-
+</div>
+<div data-lang="Spark" markdown="1">
+    $SPARK_HOME/bin/spark-submit --master yarn-cluster
+                                 --conf spark.driver.maxResultSize=0
+                                 --conf spark.akka.frameSize=128
+                                 SystemML.jar
+                                 -f StepLinearRegDS.dml
+                                 -config=SystemML-config.xml
+                                 -exec hybrid_spark
+                                 -nvargs X=<file>
+                                         Y=<file>
+                                         B=<file>
+                                         S=[file]
+                                         O=[file]
+                                         icpt=[int]
+                                         thr=[double]
+                                         fmt=[format]
+</div>
+</div>
 
 ### Arguments
 
@@ -419,6 +522,8 @@ SystemML Language Reference for details.
 
 ### Examples
 
+<div class="codetabs">
+<div data-lang="Hadoop" markdown="1">
     hadoop jar SystemML.jar -f StepLinearRegDS.dml
                             -nvargs X=/user/ml/X.mtx
                                     Y=/user/ml/Y.mtx
@@ -428,6 +533,25 @@ SystemML Language Reference for details.
                                     icpt=2
                                     thr=0.05
                                     fmt=csv
+</div>
+<div data-lang="Spark" markdown="1">
+    $SPARK_HOME/bin/spark-submit --master yarn-cluster
+                                 --conf spark.driver.maxResultSize=0
+                                 --conf spark.akka.frameSize=128
+                                 SystemML.jar
+                                 -f StepLinearRegDS.dml
+                                 -config=SystemML-config.xml
+                                 -exec hybrid_spark
+                                 -nvargs X=/user/ml/X.mtx
+                                         Y=/user/ml/Y.mtx
+                                         B=/user/ml/B.mtx
+                                         S=/user/ml/selected.csv
+                                         O=/user/ml/stats.csv
+                                         icpt=2
+                                         thr=0.05
+                                         fmt=csv
+</div>
+</div>
 
 
 ### Details
@@ -521,6 +645,8 @@ distributions and link functions, see below for details.
 
 ### Usage
 
+<div class="codetabs">
+<div data-lang="Hadoop" markdown="1">
     hadoop jar SystemML.jar -f GLM.dml
                             -nvargs X=<file>
                                     Y=<file>
@@ -539,7 +665,34 @@ distributions and link functions, see below for details.
                                     disp=[double]
                                     moi=[int]
                                     mii=[int]
-
+</div>
+<div data-lang="Spark" markdown="1">
+    $SPARK_HOME/bin/spark-submit --master yarn-cluster
+                                 --conf spark.driver.maxResultSize=0
+                                 --conf spark.akka.frameSize=128
+                                 SystemML.jar
+                                 -f GLM.dml
+                                 -config=SystemML-config.xml
+                                 -exec hybrid_spark
+                                 -nvargs X=<file>
+                                         Y=<file>
+                                         B=<file>
+                                         fmt=[format]
+                                         O=[file]
+                                         Log=[file]
+                                         dfam=[int]
+                                         vpow=[double]
+                                         link=[int]
+                                         lpow=[double]
+                                         yneg=[double]
+                                         icpt=[int]
+                                         reg=[double]
+                                         tol=[double]
+                                         disp=[double]
+                                         moi=[int]
+                                         mii=[int]
+</div>
+</div>
 
 ### Arguments
 
@@ -629,27 +782,53 @@ data
 **mii**: (default: `0`) Maximum number of inner (conjugate gradient) iterations, or 0
 if no maximum limit provided
 
-* * *
 
 ### Examples
 
+<div class="codetabs">
+<div data-lang="Hadoop" markdown="1">
     hadoop jar SystemML.jar -f GLM.dml
-                            -nvargs X=/user/ml/X.mtx 
-                                    Y=/user/ml/Y.mtx 
-                                    B=/user/ml/B.mtx 
-                                    fmt=csv 
-                                    dfam=2 
-                                    link=2 
-                                    yneg=-1.0 
-                                    icpt=2 
-                                    reg=0.01 
-                                    tol=0.00000001 
-                                    disp=1.0 
-                                    moi=100 
-                                    mii=10 
-                                    O=/user/ml/stats.csv 
+                            -nvargs X=/user/ml/X.mtx
+                                    Y=/user/ml/Y.mtx
+                                    B=/user/ml/B.mtx
+                                    fmt=csv
+                                    dfam=2
+                                    link=2
+                                    yneg=-1.0
+                                    icpt=2
+                                    reg=0.01
+                                    tol=0.00000001
+                                    disp=1.0
+                                    moi=100
+                                    mii=10
+                                    O=/user/ml/stats.csv
                                     Log=/user/ml/log.csv
-
+</div>
+<div data-lang="Spark" markdown="1">
+    $SPARK_HOME/bin/spark-submit --master yarn-cluster
+                                 --conf spark.driver.maxResultSize=0
+                                 --conf spark.akka.frameSize=128
+                                 SystemML.jar
+                                 -f GLM.dml
+                                 -config=SystemML-config.xml
+                                 -exec hybrid_spark
+                                 -nvargs X=/user/ml/X.mtx
+                                         Y=/user/ml/Y.mtx
+                                         B=/user/ml/B.mtx
+                                         fmt=csv
+                                         dfam=2
+                                         link=2
+                                         yneg=-1.0
+                                         icpt=2
+                                         reg=0.01
+                                         tol=0.00000001
+                                         disp=1.0
+                                         moi=100
+                                         mii=10
+                                         O=/user/ml/stats.csv
+                                         Log=/user/ml/log.csv
+</div>
+</div>
 
 * * *
 
@@ -944,6 +1123,8 @@ distribution family is supported (see below for details).
 
 ### Usage
 
+<div class="codetabs">
+<div data-lang="Hadoop" markdown="1">
     hadoop jar SystemML.jar -f StepGLM.dml
                             -nvargs X=<file>
                                     Y=<file>
@@ -959,6 +1140,31 @@ distribution family is supported (see below for details).
                                     mii=[int]
                                     thr=[double]
                                     fmt=[format]
+</div>
+<div data-lang="Spark" markdown="1">
+    $SPARK_HOME/bin/spark-submit --master yarn-cluster
+                                 --conf spark.driver.maxResultSize=0
+                                 --conf spark.akka.frameSize=128
+                                 SystemML.jar
+                                 -f StepGLM.dml
+                                 -config=SystemML-config.xml
+                                 -exec hybrid_spark
+                                 -nvargs X=<file>
+                                         Y=<file>
+                                         B=<file>
+                                         S=[file]
+                                         O=[file]
+                                         link=[int]
+                                         yneg=[double]
+                                         icpt=[int]
+                                         tol=[double]
+                                         disp=[double]
+                                         moi=[int]
+                                         mii=[int]
+                                         thr=[double]
+                                         fmt=[format]
+</div>
+</div>
 
 
 ### Arguments
@@ -1023,6 +1229,8 @@ SystemML Language Reference for details.
 
 ### Examples
 
+<div class="codetabs">
+<div data-lang="Hadoop" markdown="1">
     hadoop jar SystemML.jar -f StepGLM.dml
                             -nvargs X=/user/ml/X.mtx
                                     Y=/user/ml/Y.mtx
@@ -1037,6 +1245,30 @@ SystemML Language Reference for details.
                                     mii=10
                                     thr=0.05
                                     fmt=csv
+</div>
+<div data-lang="Spark" markdown="1">
+    $SPARK_HOME/bin/spark-submit --master yarn-cluster
+                                 --conf spark.driver.maxResultSize=0
+                                 --conf spark.akka.frameSize=128
+                                 SystemML.jar
+                                 -f StepGLM.dml
+                                 -config=SystemML-config.xml
+                                 -exec hybrid_spark
+                                 -nvargs X=/user/ml/X.mtx
+                                         Y=/user/ml/Y.mtx
+                                         B=/user/ml/B.mtx
+                                         S=/user/ml/selected.csv
+                                         O=/user/ml/stats.csv
+                                         link=2
+                                         yneg=-1.0
+                                         icpt=2
+                                         tol=0.000001
+                                         moi=100
+                                         mii=10
+                                         thr=0.05
+                                         fmt=csv
+</div>
+</div>
 
 
 ### Details
@@ -1145,6 +1377,8 @@ this step outside the scope of `GLM-predict.dml` for now.
 
 ### Usage
 
+<div class="codetabs">
+<div data-lang="Hadoop" markdown="1">
     hadoop jar SystemML.jar -f GLM-predict.dml
                             -nvargs X=<file>
                                     Y=[file]
@@ -1157,6 +1391,28 @@ this step outside the scope of `GLM-predict.dml` for now.
                                     lpow=[double]
                                     disp=[double]
                                     fmt=[format]
+</div>
+<div data-lang="Spark" markdown="1">
+    $SPARK_HOME/bin/spark-submit --master yarn-cluster
+                                 --conf spark.driver.maxResultSize=0
+                                 --conf spark.akka.frameSize=128
+                                 SystemML.jar
+                                 -f GLM-predict.dml
+                                 -config=SystemML-config.xml
+                                 -exec hybrid_spark
+                                 -nvargs X=<file>
+                                         Y=[file]
+                                         B=<file>
+                                         M=[file]
+                                         O=[file]
+                                         dfam=[int]
+                                         vpow=[double]
+                                         link=[int]
+                                         lpow=[double]
+                                         disp=[double]
+                                         fmt=[format]
+</div>
+</div>
 
 
 ### Arguments
@@ -1258,101 +1514,256 @@ argument is set arbitrarily. The correct dispersion value should be
 computed from the training data during model estimation, or omitted if
 unknown (which sets it to `1.0`).
 
-Linear regression example:
+**Linear regression example**:
 
+<div class="codetabs">
+<div data-lang="Hadoop" markdown="1">
     hadoop jar SystemML.jar -f GLM-predict.dml
-                            -nvargs dfam=1 
-                                    vpow=0.0 
-                                    link=1 
-                                    lpow=1.0 
-                                    disp=5.67 
-                                    X=/user/ml/X.mtx 
-                                    B=/user/ml/B.mtx 
-                                    M=/user/ml/Means.mtx 
-                                    fmt=csv 
-                                    Y=/user/ml/Y.mtx 
-                                    O=/user/ml/stats.csv
-
-
-Linear regression example, prediction only (no Y given):
-
-    hadoop jar SystemML.jar -f GLM-predict.dml
-                            -nvargs dfam=1 
-                                    vpow=0.0 
-                                    link=1 
-                                    lpow=1.0 
-                                    X=/user/ml/X.mtx 
-                                    B=/user/ml/B.mtx 
-                                    M=/user/ml/Means.mtx 
+                            -nvargs dfam=1
+                                    vpow=0.0
+                                    link=1
+                                    lpow=1.0
+                                    disp=5.67
+                                    X=/user/ml/X.mtx
+                                    B=/user/ml/B.mtx
+                                    M=/user/ml/Means.mtx
                                     fmt=csv
-
-Binomial logistic regression example:
-
-    hadoop jar SystemML.jar -f GLM-predict.dml
-                            -nvargs dfam=2 
-                                    link=2 
-                                    disp=3.0004464 
-                                    X=/user/ml/X.mtx 
-                                    B=/user/ml/B.mtx 
-                                    M=/user/ml/Probabilities.mtx 
-                                    fmt=csv 
-                                    Y=/user/ml/Y.mtx 
+                                    Y=/user/ml/Y.mtx
                                     O=/user/ml/stats.csv
+</div>
+<div data-lang="Spark" markdown="1">
+    $SPARK_HOME/bin/spark-submit --master yarn-cluster
+                                 --conf spark.driver.maxResultSize=0
+                                 --conf spark.akka.frameSize=128
+                                 SystemML.jar
+                                 -f GLM-predict.dml
+                                 -config=SystemML-config.xml
+                                 -exec hybrid_spark
+                                 -nvargs dfam=1
+                                         vpow=0.0
+                                         link=1
+                                         lpow=1.0
+                                         disp=5.67
+                                         X=/user/ml/X.mtx
+                                         B=/user/ml/B.mtx
+                                         M=/user/ml/Means.mtx
+                                         fmt=csv
+                                         Y=/user/ml/Y.mtx
+                                         O=/user/ml/stats.csv
+</div>
+</div>
 
-Binomial probit regression example:
+**Linear regression example, prediction only (no Y given)**:
 
+<div class="codetabs">
+<div data-lang="Hadoop" markdown="1">
     hadoop jar SystemML.jar -f GLM-predict.dml
-                            -nvargs dfam=2 
-                                    link=3 
-                                    disp=3.0004464 
-                                    X=/user/ml/X.mtx 
-                                    B=/user/ml/B.mtx 
-                                    M=/user/ml/Probabilities.mtx 
-                                    fmt=csv 
-                                    Y=/user/ml/Y.mtx 
+                            -nvargs dfam=1
+                                    vpow=0.0
+                                    link=1
+                                    lpow=1.0
+                                    X=/user/ml/X.mtx
+                                    B=/user/ml/B.mtx
+                                    M=/user/ml/Means.mtx
+                                    fmt=csv
+</div>
+<div data-lang="Spark" markdown="1">
+    $SPARK_HOME/bin/spark-submit --master yarn-cluster
+                                 --conf spark.driver.maxResultSize=0
+                                 --conf spark.akka.frameSize=128
+                                 SystemML.jar
+                                 -f GLM-predict.dml
+                                 -config=SystemML-config.xml
+                                 -exec hybrid_spark
+                                 -nvargs dfam=1
+                                         vpow=0.0
+                                         link=1
+                                         lpow=1.0
+                                         X=/user/ml/X.mtx
+                                         B=/user/ml/B.mtx
+                                         M=/user/ml/Means.mtx
+                                         fmt=csv
+</div>
+</div>
+
+**Binomial logistic regression example**:
+
+<div class="codetabs">
+<div data-lang="Hadoop" markdown="1">
+    hadoop jar SystemML.jar -f GLM-predict.dml
+                            -nvargs dfam=2
+                                    link=2
+                                    disp=3.0004464
+                                    X=/user/ml/X.mtx
+                                    B=/user/ml/B.mtx
+                                    M=/user/ml/Probabilities.mtx
+                                    fmt=csv
+                                    Y=/user/ml/Y.mtx
                                     O=/user/ml/stats.csv
+</div>
+<div data-lang="Spark" markdown="1">
+    $SPARK_HOME/bin/spark-submit --master yarn-cluster
+                                 --conf spark.driver.maxResultSize=0
+                                 --conf spark.akka.frameSize=128
+                                 SystemML.jar
+                                 -f GLM-predict.dml
+                                 -config=SystemML-config.xml
+                                 -exec hybrid_spark
+                                 -nvargs dfam=2
+                                         link=2
+                                         disp=3.0004464
+                                         X=/user/ml/X.mtx
+                                         B=/user/ml/B.mtx
+                                         M=/user/ml/Probabilities.mtx
+                                         fmt=csv
+                                         Y=/user/ml/Y.mtx
+                                         O=/user/ml/stats.csv
+</div>
+</div>
 
-Multinomial logistic regression example:
+**Binomial probit regression example**:
 
+<div class="codetabs">
+<div data-lang="Hadoop" markdown="1">
+    hadoop jar SystemML.jar -f GLM-predict.dml
+                            -nvargs dfam=2
+                                    link=3
+                                    disp=3.0004464
+                                    X=/user/ml/X.mtx
+                                    B=/user/ml/B.mtx
+                                    M=/user/ml/Probabilities.mtx
+                                    fmt=csv
+                                    Y=/user/ml/Y.mtx
+                                    O=/user/ml/stats.csv
+</div>
+<div data-lang="Spark" markdown="1">
+    $SPARK_HOME/bin/spark-submit --master yarn-cluster
+                                 --conf spark.driver.maxResultSize=0
+                                 --conf spark.akka.frameSize=128
+                                 SystemML.jar
+                                 -f GLM-predict.dml
+                                 -config=SystemML-config.xml
+                                 -exec hybrid_spark
+                                 -nvargs dfam=2
+                                         link=3
+                                         disp=3.0004464
+                                         X=/user/ml/X.mtx
+                                         B=/user/ml/B.mtx
+                                         M=/user/ml/Probabilities.mtx
+                                         fmt=csv
+                                         Y=/user/ml/Y.mtx
+                                         O=/user/ml/stats.csv
+</div>
+</div>
+
+**Multinomial logistic regression example**:
+
+<div class="codetabs">
+<div data-lang="Hadoop" markdown="1">
     hadoop jar SystemML.jar -f GLM-predict.dml
                             -nvargs dfam=3 
-                                    X=/user/ml/X.mtx 
-                                    B=/user/ml/B.mtx 
-                                    M=/user/ml/Probabilities.mtx 
-                                    fmt=csv 
-                                    Y=/user/ml/Y.mtx 
+                                    X=/user/ml/X.mtx
+                                    B=/user/ml/B.mtx
+                                    M=/user/ml/Probabilities.mtx
+                                    fmt=csv
+                                    Y=/user/ml/Y.mtx
                                     O=/user/ml/stats.csv
+</div>
+<div data-lang="Spark" markdown="1">
+    $SPARK_HOME/bin/spark-submit --master yarn-cluster
+                                 --conf spark.driver.maxResultSize=0
+                                 --conf spark.akka.frameSize=128
+                                 SystemML.jar
+                                 -f GLM-predict.dml
+                                 -config=SystemML-config.xml
+                                 -exec hybrid_spark
+                                 -nvargs dfam=3
+                                         X=/user/ml/X.mtx
+                                         B=/user/ml/B.mtx
+                                         M=/user/ml/Probabilities.mtx
+                                         fmt=csv
+                                         Y=/user/ml/Y.mtx
+                                         O=/user/ml/stats.csv
+</div>
+</div>
 
-Poisson regression with the log link example:
+**Poisson regression with the log link example**:
 
+<div class="codetabs">
+<div data-lang="Hadoop" markdown="1">
     hadoop jar SystemML.jar -f GLM-predict.dml
-                            -nvargs dfam=1 
-                                    vpow=1.0 
-                                    link=1 
-                                    lpow=0.0 
-                                    disp=3.45 
-                                    X=/user/ml/X.mtx 
-                                    B=/user/ml/B.mtx 
-                                    M=/user/ml/Means.mtx 
-                                    fmt=csv 
-                                    Y=/user/ml/Y.mtx 
+                            -nvargs dfam=1
+                                    vpow=1.0
+                                    link=1
+                                    lpow=0.0
+                                    disp=3.45
+                                    X=/user/ml/X.mtx
+                                    B=/user/ml/B.mtx
+                                    M=/user/ml/Means.mtx
+                                    fmt=csv
+                                    Y=/user/ml/Y.mtx
                                     O=/user/ml/stats.csv
+</div>
+<div data-lang="Spark" markdown="1">
+    $SPARK_HOME/bin/spark-submit --master yarn-cluster
+                                 --conf spark.driver.maxResultSize=0
+                                 --conf spark.akka.frameSize=128
+                                 SystemML.jar
+                                 -f GLM-predict.dml
+                                 -config=SystemML-config.xml
+                                 -exec hybrid_spark
+                                 -nvargs dfam=1
+                                         vpow=1.0
+                                         link=1
+                                         lpow=0.0
+                                         disp=3.45
+                                         X=/user/ml/X.mtx
+                                         B=/user/ml/B.mtx
+                                         M=/user/ml/Means.mtx
+                                         fmt=csv
+                                         Y=/user/ml/Y.mtx
+                                         O=/user/ml/stats.csv
+</div>
+</div>
 
-Gamma regression with the inverse (reciprocal) link example:
+**Gamma regression with the inverse (reciprocal) link example**:
 
+<div class="codetabs">
+<div data-lang="Hadoop" markdown="1">
     hadoop jar SystemML.jar -f GLM-predict.dml
-                            -nvargs dfam=1 
-                                    vpow=2.0 
-                                    link=1 
-                                    lpow=-1.0 
-                                    disp=1.99118 
-                                    X=/user/ml/X.mtx 
-                                    B=/user/ml/B.mtx 
-                                    M=/user/ml/Means.mtx 
-                                    fmt=csv 
-                                    Y=/user/ml/Y.mtx 
+                            -nvargs dfam=1
+                                    vpow=2.0
+                                    link=1
+                                    lpow=-1.0
+                                    disp=1.99118
+                                    X=/user/ml/X.mtx
+                                    B=/user/ml/B.mtx
+                                    M=/user/ml/Means.mtx
+                                    fmt=csv
+                                    Y=/user/ml/Y.mtx
                                     O=/user/ml/stats.csv
-
+</div>
+<div data-lang="Spark" markdown="1">
+    $SPARK_HOME/bin/spark-submit --master yarn-cluster
+                                 --conf spark.driver.maxResultSize=0
+                                 --conf spark.akka.frameSize=128
+                                 SystemML.jar
+                                 -f GLM-predict.dml
+                                 -config=SystemML-config.xml
+                                 -exec hybrid_spark
+                                 -nvargs dfam=1
+                                         vpow=2.0
+                                         link=1
+                                         lpow=-1.0
+                                         disp=1.99118
+                                         X=/user/ml/X.mtx
+                                         B=/user/ml/B.mtx
+                                         M=/user/ml/Means.mtx
+                                         fmt=csv
+                                         Y=/user/ml/Y.mtx
+                                         O=/user/ml/stats.csv
+</div>
+</div>
 
 * * *
 

--- a/system-ml/docs/algorithms-survival-analysis.md
+++ b/system-ml/docs/algorithms-survival-analysis.md
@@ -23,6 +23,8 @@ censored and uncensored survival times.
 
 ### Usage
 
+<div class="codetabs">
+<div data-lang="Hadoop" markdown="1">
     hadoop jar SystemML.jar -f KM.dml
                             -nvargs X=<file>
                                     TE=<file>
@@ -36,6 +38,29 @@ censored and uncensored survival times.
                                     ctype=[plain|log|log-log]
                                     ttype=[none|log-rank|wilcoxon]
                                     fmt=[format]
+</div>
+<div data-lang="Spark" markdown="1">
+    $SPARK_HOME/bin/spark-submit --master yarn-cluster
+                                 --conf spark.driver.maxResultSize=0
+                                 --conf spark.akka.frameSize=128
+                                 SystemML.jar
+                                 -f KM.dml
+                                 -config=SystemML-config.xml
+                                 -exec hybrid_spark
+                                 -nvargs X=<file>
+                                         TE=<file>
+                                         GI=<file>
+                                         SI=<file>
+                                         O=<file>
+                                         M=<file>
+                                         T=<file>
+                                         alpha=[double]
+                                         etype=[greenwood|peto]
+                                         ctype=[plain|log|log-log]
+                                         ttype=[none|log-rank|wilcoxon]
+                                         fmt=[format]
+</div>
+</div>
 
 
 ### Arguments
@@ -95,6 +120,8 @@ SystemML Language Reference for details.
 
 ### Examples
 
+<div class="codetabs">
+<div data-lang="Hadoop" markdown="1">
     hadoop jar SystemML.jar -f KM.dml
                             -nvargs X=/user/ml/X.mtx
                                     TE=/user/ml/TE
@@ -106,7 +133,30 @@ SystemML Language Reference for details.
                                     etype=greenwood
                                     ctype=plain
                                     fmt=csv
+</div>
+<div data-lang="Spark" markdown="1">
+    $SPARK_HOME/bin/spark-submit --master yarn-cluster
+                                 --conf spark.driver.maxResultSize=0
+                                 --conf spark.akka.frameSize=128
+                                 SystemML.jar
+                                 -f KM.dml
+                                 -config=SystemML-config.xml
+                                 -exec hybrid_spark
+                                 -nvargs X=/user/ml/X.mtx
+                                         TE=/user/ml/TE
+                                         GI=/user/ml/GI
+                                         SI=/user/ml/SI
+                                         O=/user/ml/kaplan-meier.csv
+                                         M=/user/ml/model.csv
+                                         alpha=0.01
+                                         etype=greenwood
+                                         ctype=plain
+                                         fmt=csv
+</div>
+</div>
 
+<div class="codetabs">
+<div data-lang="Hadoop" markdown="1">
     hadoop jar SystemML.jar -f KM.dml
                             -nvargs X=/user/ml/X.mtx
                                     TE=/user/ml/TE
@@ -120,6 +170,29 @@ SystemML Language Reference for details.
                                     ctype=log
                                     ttype=log-rank
                                     fmt=csv
+</div>
+<div data-lang="Spark" markdown="1">
+    $SPARK_HOME/bin/spark-submit --master yarn-cluster
+                                 --conf spark.driver.maxResultSize=0
+                                 --conf spark.akka.frameSize=128
+                                 SystemML.jar
+                                 -f KM.dml
+                                 -config=SystemML-config.xml
+                                 -exec hybrid_spark
+                                 -nvargs X=/user/ml/X.mtx
+                                         TE=/user/ml/TE
+                                         GI=/user/ml/GI
+                                         SI=/user/ml/SI
+                                         O=/user/ml/kaplan-meier.csv
+                                         M=/user/ml/model.csv
+                                         T=/user/ml/test.csv
+                                         alpha=0.01
+                                         etype=peto
+                                         ctype=log
+                                         ttype=log-rank
+                                         fmt=csv
+</div>
+</div>
 
 
 ### Details
@@ -350,6 +423,8 @@ may be categorical (ordinal or nominal) as well as continuous-valued.
 
 **Cox**:
 
+<div class="codetabs">
+<div data-lang="Hadoop" markdown="1">
     hadoop jar SystemML.jar -f Cox.dml
                             -nvargs X=<file>
                                     TE=<file>
@@ -367,9 +442,39 @@ may be categorical (ordinal or nominal) as well as continuous-valued.
                                     moi=[int]
                                     mii=[int]
                                     fmt=[format]
+</div>
+<div data-lang="Spark" markdown="1">
+    $SPARK_HOME/bin/spark-submit --master yarn-cluster
+                                 --conf spark.driver.maxResultSize=0
+                                 --conf spark.akka.frameSize=128
+                                 SystemML.jar
+                                 -f Cox.dml
+                                 -config=SystemML-config.xml
+                                 -exec hybrid_spark
+                                 -nvargs X=<file>
+                                         TE=<file>
+                                         F=<file>
+                                         R=[file]
+                                         M=<file>
+                                         S=[file]
+                                         T=[file]
+                                         COV=<file>
+                                         RT=<file>
+                                         XO=<file>
+                                         MF=<file>
+                                         alpha=[double]
+                                         tol=[double]
+                                         moi=[int]
+                                         mii=[int]
+                                         fmt=[format]
+</div>
+</div>
+
 
 **Cox Prediction**:
 
+<div class="codetabs">
+<div data-lang="Hadoop" markdown="1">
     hadoop jar SystemML.jar -f Cox-predict.dml
                             -nvargs X=<file>
                                     RT=<file>
@@ -379,6 +484,26 @@ may be categorical (ordinal or nominal) as well as continuous-valued.
                                     MF=<file>
                                     P=<file>
                                     fmt=[format]
+</div>
+<div data-lang="Spark" markdown="1">
+    $SPARK_HOME/bin/spark-submit --master yarn-cluster
+                                 --conf spark.driver.maxResultSize=0
+                                 --conf spark.akka.frameSize=128
+                                 SystemML.jar
+                                 -f Cox-predict.dml
+                                 -config=SystemML-config.xml
+                                 -exec hybrid_spark
+                                 -nvargs X=<file>
+                                         RT=<file>
+                                         M=<file>
+                                         Y=<file>
+                                         COV=<file>
+                                         MF=<file>
+                                         P=<file>
+                                         fmt=[format]
+</div>
+</div>
+
 
 ### Arguments - Cox Model Fitting/Prediction
 
@@ -456,6 +581,8 @@ SystemML Language Reference for details.
 
 **Cox**:
 
+<div class="codetabs">
+<div data-lang="Hadoop" markdown="1">
     hadoop jar SystemML.jar -f Cox.dml
                             -nvargs X=/user/ml/X.mtx
                                     TE=/user/ml/TE
@@ -466,7 +593,29 @@ SystemML Language Reference for details.
                                     COV=/user/ml/var-covar.csv
                                     XO=/user/ml/X-sorted.mtx
                                     fmt=csv
+</div>
+<div data-lang="Spark" markdown="1">
+    $SPARK_HOME/bin/spark-submit --master yarn-cluster
+                                 --conf spark.driver.maxResultSize=0
+                                 --conf spark.akka.frameSize=128
+                                 SystemML.jar
+                                 -f Cox.dml
+                                 -config=SystemML-config.xml
+                                 -exec hybrid_spark
+                                 -nvargs X=/user/ml/X.mtx
+                                         TE=/user/ml/TE
+                                         F=/user/ml/F
+                                         R=/user/ml/R
+                                         M=/user/ml/model.csv
+                                         T=/user/ml/test.csv
+                                         COV=/user/ml/var-covar.csv
+                                         XO=/user/ml/X-sorted.mtx
+                                         fmt=csv
+</div>
+</div>
 
+<div class="codetabs">
+<div data-lang="Hadoop" markdown="1">
     hadoop jar SystemML.jar -f Cox.dml
                             -nvargs X=/user/ml/X.mtx
                                     TE=/user/ml/TE
@@ -483,9 +632,37 @@ SystemML Language Reference for details.
                                     moi=100
                                     mii=20
                                     fmt=csv
+</div>
+<div data-lang="Spark" markdown="1">
+    $SPARK_HOME/bin/spark-submit --master yarn-cluster
+                                 --conf spark.driver.maxResultSize=0
+                                 --conf spark.akka.frameSize=128
+                                 SystemML.jar
+                                 -f Cox.dml
+                                 -config=SystemML-config.xml
+                                 -exec hybrid_spark
+                                 -nvargs X=/user/ml/X.mtx
+                                         TE=/user/ml/TE
+                                         F=/user/ml/F
+                                         R=/user/ml/R
+                                         M=/user/ml/model.csv
+                                         T=/user/ml/test.csv
+                                         COV=/user/ml/var-covar.csv
+                                         RT=/user/ml/recoded-timestamps.csv
+                                         XO=/user/ml/X-sorted.csv
+                                         MF=/user/ml/baseline.csv
+                                         alpha=0.01
+                                         tol=0.000001
+                                         moi=100
+                                         mii=20
+                                         fmt=csv
+</div>
+</div>
 
 **Cox Prediction**:
 
+<div class="codetabs">
+<div data-lang="Hadoop" markdown="1">
     hadoop jar SystemML.jar -f Cox-predict.dml
                             -nvargs X=/user/ml/X-sorted.mtx
                                     RT=/user/ml/recoded-timestamps.csv
@@ -495,6 +672,25 @@ SystemML Language Reference for details.
                                     MF=/user/ml/baseline.csv
                                     P=/user/ml/predictions.csv
                                     fmt=csv
+</div>
+<div data-lang="Spark" markdown="1">
+    $SPARK_HOME/bin/spark-submit --master yarn-cluster
+                                 --conf spark.driver.maxResultSize=0
+                                 --conf spark.akka.frameSize=128
+                                 SystemML.jar
+                                 -f Cox-predict.dml
+                                 -config=SystemML-config.xml
+                                 -exec hybrid_spark
+                                 -nvargs X=/user/ml/X-sorted.mtx
+                                         RT=/user/ml/recoded-timestamps.csv
+                                         M=/user/ml/model.csv
+                                         Y=/user/ml/Y.mtx
+                                         COV=/user/ml/var-covar.csv
+                                         MF=/user/ml/baseline.csv
+                                         P=/user/ml/predictions.csv
+                                         fmt=csv
+</div>
+</div>
 
 
 ### Details
@@ -671,7 +867,7 @@ follows. File `S` stores the following information
   * Line 5: Cox & Snell Rsquare
   * Line 6: maximum possible Rsquare.
 
-Above, the AIC is computed as in [[Stepwise Linear Regression]](algorithms-regression.html#stepwise-linear-regression), the Cox & Snell Rsquare
+Above, the AIC is computed as in [Stepwise Linear Regression](algorithms-regression.html#stepwise-linear-regression), the Cox & Snell Rsquare
 is equal to $$1-\exp\{ -l/n \}$$, where $l$ is the log-rank test statistic
 as discussed above and $n$ is total number of observations, and the
 maximum possible Rsquare computed as $$1-\exp\{ -2 L(\textbf{0})/n \}$$,

--- a/system-ml/docs/dml-and-pydml-programming-guide.md
+++ b/system-ml/docs/dml-and-pydml-programming-guide.md
@@ -52,7 +52,7 @@ The `DMLScript` class serves as the main entrypoint to SystemML. Executing
 In Eclipse, a Debug Configuration can be created with `DMLScript` as the Main class and any arguments specified as
 Program arguments. A PyDML script requires the addition of a `-python` switch.
 
-<div class="codetabs">
+<div class="codetabs2">
 
 <div data-lang="Eclipse Debug Configuration - Main" markdown="1">
 ![Eclipse Debug Configuration - Main](img/dml-and-pydml-programming-guide/dmlscript-debug-configuration-hello-world-main-class.png "DMLScript Debug Configuration, Main class")
@@ -81,7 +81,7 @@ based on its value. Mathematical operations typically operate on
 doubles/floats, whereas integers/ints are typically useful for tasks such as
 iteration and accessing elements in a matrix.
 
-<div class="codetabs">
+<div class="codetabs2">
 
 <div data-lang="DML" markdown="1">
 {% highlight r %}
@@ -161,7 +161,7 @@ function. In the example below, a matrix element is still considered to be of th
 so the value is cast to a scalar in order to print it. Matrix element values are of type **double**/**float**.
 *Note that matrices index from 1 in both DML and PyDML.*
 
-<div class="codetabs">
+<div class="codetabs2">
 
 <div data-lang="DML" markdown="1">
 {% highlight r %}
@@ -212,7 +212,7 @@ PyDML Language Reference (Matrix Construction).
 A matrix can be saved using the **`write()`** function in DML and the **`save()`** function in PyDML. SystemML supports four
 different formats: **`text`** (`i,j,v`), **`mm`** (`Matrix Market`), **`csv`** (`delimiter-separated values`), and **`binary`**.
 
-<div class="codetabs">
+<div class="codetabs2">
 
 <div data-lang="DML" markdown="1">
 {% highlight r %}
@@ -239,7 +239,7 @@ save(m, "m.binary", format="binary")
 Saving a matrix automatically creates a metadata file for each format except for Matrix Market, since Matrix Market contains
 metadata within the *.mm file. All formats are text-based except binary. The contents of the resulting files are shown here.
 
-<div class="codetabs">
+<div class="codetabs2">
 
 <div data-lang="m.txt" markdown="1">
 	1 1 1.0
@@ -321,7 +321,7 @@ A matrix can be loaded using the **`read()`** function in DML and the **`load()`
 formats: **`text`** (`i,j,v`), **`mm`** (`Matrix Market`), **`csv`** (`delimiter-separated values`), and **`binary`**. To read a file, a corresponding
 metadata file is required, except for the Matrix Market format.
 
-<div class="codetabs">
+<div class="codetabs2">
 
 <div data-lang="DML" markdown="1">
 {% highlight r %}
@@ -387,7 +387,7 @@ by 2 and assign the resulting matrix to D.
 This example also shows a user-defined function called `printMatrix()`, which takes a string and matrix as arguments and returns
 nothing.
 
-<div class="codetabs">
+<div class="codetabs2">
 
 <div data-lang="DML" markdown="1">
 {% highlight r %}
@@ -471,7 +471,7 @@ specifying row 2 and leaving the column blank. We obtain a column slice (vector)
 column 3. After that, we obtain a submatrix via range indexing, where we specify rows 2 to 3, separated by a colon, and columns
 1 to 2, separated by a colon.
 
-<div class="codetabs">
+<div class="codetabs2">
 
 <div data-lang="DML" markdown="1">
 {% highlight r %}
@@ -557,7 +557,7 @@ DML and PyDML feature 3 loop statements: `while`, `for`, and `parfor` (parallel 
 sequentially as in a regular `for` loop. The `parfor` statement can include several optional parameters, as described
 in the DML Language Reference ([ParFor Statement](dml-language-reference.html#parfor-statement)) and PyDML Language Reference (ParFor Statement).
 
-<div class="codetabs">
+<div class="codetabs2">
 
 <div data-lang="DML" markdown="1">
 {% highlight r %}
@@ -623,7 +623,7 @@ Functions encapsulate useful functionality in SystemML. In addition to built-in 
 Functions take 0 or more parameters and return 0 or more values.
 Currently, if a function returns nothing, it still needs to be assigned to a variable.
 
-<div class="codetabs">
+<div class="codetabs2">
 
 <div data-lang="DML" markdown="1">
 {% highlight r %}
@@ -669,7 +669,7 @@ is appended to the matrix. A column consisting of the row sums is appended to th
 matrix is returned to variable B. Matrix A is output to the `A.csv` file and matrix B is saved as the `B.csv` file.
 
 
-<div class="codetabs">
+<div class="codetabs2">
 
 <div data-lang="A.csv" markdown="1">
 	1.6091961493071,0.7088614208099939
@@ -698,7 +698,7 @@ In the example below, a matrix is read from the file system using named argument
 using the `rowsToPrint` argument, which defaults to 2 if no argument is supplied. Likewise, the number of columns is
 specified using `colsToPrint` with a default value of 2.
 
-<div class="codetabs">
+<div class="codetabs2">
 
 <div data-lang="DML" markdown="1">
 {% highlight r %}
@@ -780,7 +780,7 @@ for (i in 1:numRowsToPrint):
 
 Here, we see identical functionality but with positional arguments.
 
-<div class="codetabs">
+<div class="codetabs2">
 
 <div data-lang="DML" markdown="1">
 {% highlight r %}

--- a/system-ml/docs/js/main.js
+++ b/system-ml/docs/js/main.js
@@ -18,6 +18,7 @@
 /* Custom JavaScript code in the MarkDown docs */
 
 // Enable language-specific code tabs
+// similar to spark code tabs, except can have spaces and periods
 function codeTabs() {
   var counter = 0;
   var langImages = {
@@ -39,12 +40,78 @@ function codeTabs() {
       var lang = $(this).data("lang");
       var image = $(this).data("image");
       var notabs = $(this).data("notabs");
+      var capitalizedLang = lang.substr(0, 1).toUpperCase() + lang.substr(1);
+      
+      // for flexibility, allow spaces and periods
       var langConv = lang.replace(/\./g, "_");
       langConv = langConv.replace(/ /g, "_");
+      
       var id = "tab_" + langConv + "_" + counter;
       $(this).attr("id", id);
       if (image != null && langImages[lang]) {
         var buttonLabel = "<img src='" +langImages[lang] + "' alt='" + capitalizedLang + "' />";
+      } else if (notabs == null) {
+        var buttonLabel = "<b>" + capitalizedLang + "</b>";
+      } else {
+        var buttonLabel = ""
+      }
+      tabBar.append(
+        '<li><a class="tab_' + langConv + '" href="#' + id + '">' + buttonLabel + '</a></li>'
+      );
+    });
+
+    codeSamples.first().addClass("active");
+    tabBar.children("li").first().addClass("active");
+    counter++;
+  });
+  $("ul.nav-tabs a").click(function (e) {
+    // Toggling a tab should switch all tabs corresponding to the same language
+    // while retaining the scroll position
+    e.preventDefault();
+    var scrollOffset = $(this).offset().top - $(document).scrollTop();
+    $("." + $(this).attr('class')).tab('show');
+    $(document).scrollTop($(this).offset().top - scrollOffset);
+  });
+}
+
+// Code tabs that don't switch all tabs
+//
+// Note that codeTabs2() should be called after codeTabs(). If codeTabs2()
+// were called first, 2 click events would get attached to the tabs since
+// "ul.nav-tabs a" and "ul.nav-tabs2 a" would both apply. Note that 
+// nav-tabs and nav-tabs2 are both used because css doesn't support
+// inheritance, and nav-tabs has a significant amount of styling in
+// bootstrap.css.
+function codeTabs2() {
+  var counter = 0;
+  var langImages = {
+    "scala": "img/scala-sm.png",
+    "python": "img/python-sm.png",
+    "java": "img/java-sm.png"
+  };
+  $("div.codetabs2").each(function() {
+    $(this).addClass("tab-content");
+
+    // Insert the tab bar
+    var tabBar = $('<ul class="nav nav-tabs nav-tabs2" data-tabs="tabs"></ul>');
+    $(this).before(tabBar);
+
+    // Add each code sample to the tab bar:
+    var codeSamples = $(this).children("div");
+    codeSamples.each(function() {
+      $(this).addClass("tab-pane");
+      var lang = $(this).data("lang");
+      var image = $(this).data("image");
+      var notabs = $(this).data("notabs");
+      
+      // for flexibility, allow spaces and periods
+      var langConv = lang.replace(/\./g, "_");
+      langConv = langConv.replace(/ /g, "_");
+      
+      var id = "tab_" + langConv + "_" + counter;
+      $(this).attr("id", id);
+      if (image != null && langImages[lang]) {
+        var buttonLabel = "<img src='" +langImages[lang] + "' alt='" + lang + "' />";
       } else if (notabs == null) {
           var buttonLabel = "<b>" + lang + "</b>";
       } else {
@@ -59,7 +126,7 @@ function codeTabs() {
     tabBar.children("li").first().addClass("active");
     counter++;
   });
-  $("ul.nav-tabs a").click(function (e) {
+  $("ul.nav-tabs2 a").click(function (e) {
     e.preventDefault();
     var scrollOffset = $(this).offset().top - $(document).scrollTop();
     $(this).tab('show'); // only switch current tab - makes comparisons feel slightly better on this page
@@ -79,6 +146,7 @@ function maybeScrollToHash() {
 
 $(function() {
   codeTabs();
+  codeTabs2();
   // Display anchor links when hovering over headers. For documentation of the
   // configuration options, see the AnchorJS documentation.
   anchors.options = {

--- a/system-ml/docs/quick-start-guide.md
+++ b/system-ml/docs/quick-start-guide.md
@@ -17,7 +17,7 @@ about running SystemML in distributed execution mode (Hadoop, Spark) will
 be added soon.
 For more in depth information, please refer to the
 [Algorithms Reference](algorithms-reference.html) and the
-[SystemML Language Reference](dml-language-reference.html).
+[DML Language Reference](dml-language-reference.html).
 
 
 <br/>
@@ -122,9 +122,9 @@ data file `<filename>` must be `<filename>.mtd`.
 
 # Example 1 - Univariate Statistics
 
-Let's start with a simple example, computing certain [univariate statistics](systemml-algorithms-descriptive-statistics.html#univariate-statistics)
+Let's start with a simple example, computing certain [univariate statistics](algorithms-descriptive-statistics.html#univariate-statistics)
 for each feature column using the algorithm `Univar-Stats.dml` which requires 3
-[arguments](systemml-algorithms-descriptive-statistics.html#arguments):
+[arguments](algorithms-descriptive-statistics.html#arguments):
 
 * `X`:  location of the input data file to analyze
 * `TYPES`:  location of the file that contains the feature column types encoded by integer numbers: `1` = scale, `2` = nominal, `3` = ordinal
@@ -225,7 +225,7 @@ features.
 # Example 2 - Binary-class Support Vector Machines
 
 Let's take the same `haberman.data` to explore the 
-[binary-class support vector machines](systemml-algorithms-classification.html#binary-class-support-vector-machines) algorithm `l2-svm.dml`. 
+[binary-class support vector machines](algorithms-classification.html#binary-class-support-vector-machines) algorithm `l2-svm.dml`. 
 This example also illustrates how to use of the sampling algorithm `sample.dml`
 and the data split algorithm `spliXY.dml`.
 
@@ -278,7 +278,7 @@ the `splitXY.dml` algorithm on our training and test data sets.
 
 Now we need to train our model using the `l2-svm.dml` algorithm.
 
-[Parameters](systemml-algorithms-classification.html#arguments-1):
+[Parameters](algorithms-classification.html#arguments-1):
 
  * `X`         : (input)  filename of training data features
  * `Y`         : (input)  filename of training data labels
@@ -335,7 +335,7 @@ If the confusion matrix looks like this ..
 
 <br/>
 
-Refer to the *SystemML Algorithms Reference* (`docs/SystemML_Algorithms_Reference.pdf`) for more details.
+Refer to the [Algorithms Reference](algorithms-reference.html) for more details.
 
 <br/>
 
@@ -353,46 +353,8 @@ the memory available to the JVM, i.e:
 
 # Next Steps
 
-Check out the [SystemML Algorithm Reference](systemml-algorithms.html) and run
+Check out the [Algorithms Reference](algorithms-reference.html) and run
 some of the other pre-packaged algorithms.
 
-<style type="text/css">
-<!--
-    ol { list-style-type: none; counter-reset: item; margin: 1em; }
-    ol > li { display: table; counter-increment: item; margin-bottom: 0.1em; }
-    ol > li:before { content: counters(item, ".") ". "; display: table-cell; padding-right: 0.6em; }
-    li ol > li { margin: 0; }
-    li ol > li:before { content: counters(item, ".") " "; }
--->
-</style>
-
-1. Descriptive Statistics
-    - [Univariate Statistics](systemml-algorithms-descriptive-statistics.html#univariate-statistics) (`Univar-Stats.dml`)
-    - [Bivariate Statistics](systemml-algorithms-descriptive-statistics.html#bivariate-statistics) (`bivar-stats.dml`)
-    - [Stratified Bivariate Statistics](systemml-algorithms-descriptive-statistics.html#stratified-bivariate-statistics) (`stratstats.dml`)
-2. Classification
-    - [Multinomial Logistic Regression](systemml-algorithms-classification.html#multinomial-logistic-regression) (`MultiLogReg.dml`)
-    - [Binary-Class Support Vector Machines](systemml-algorithms-classification.html#binary-class-support-vector-machines) (`l2-svm.dml`, `l2-svm-predict.dml`)
-    - [Multi-Class Support Vector Machines](systemml-algorithms-classification.html#multi-class-support-vector-machines) (`m-svm.dml`, `m-svm-predict.dml`)
-    - [Naive Bayes](systemml-algorithms-classification.html#naive-bayes) (`naive-bayes.dml`, `naive-bayes-predict.dml`)
-3. Clustering
-    - [K-Means Clustering](systemml-algorithms-clustering.html#k-means-clustering) (`Kmeans.dml`, `Kmeans-predict.dml`)
-4. Regression
-    - [Linear Regression](systemml-algorithms-regression.html#linear-regression) (`LinearRegDS.dml`, `LinearRegCG.dml`)
-    - [Generalized Linear Models](systemml-algorithms-regression.html#generalized-linear-models) (`GLM.dml`)
-    - [Regression Scoring and Prediction](systemml-algorithms-regression.html#regression-scoring-and-prediction) (`GLM-predict.dml`)
-5. Matrix Factorization
-    - [Principle Component Analysis](systemml-algorithms-matrix-factorization.html#principle-component-analysis) (`PCA.dml`)
-6. Interpolation
-    - [Cubic Spline Interpolation](systemml-algorithms-interpolations.html#cubic-spline)
-   
-
-{% comment %} TODO: update the algorithms in the standalone package {% endcomment %} 
-
-{% comment %} TODO: update the algorithms reference doc to include all algorithms, currently missing decision-tree.dml {% endcomment %} 
-
-<br/>
-  
-Follow the [Programming Guide](systemml-programming-guide.html) to implement
-your own SystemML algorithms.
+Follow the [DML and PyDML Programming Guide](dml-and-pydml-programming-guide.html) to become familiar with DML and PyDML.
 


### PR DESCRIPTION
Added Hadoop and Spark tabs showing SystemML invocations to Algorithms Reference. Updated main.js for handling tabs. Updated DML and PyDML Programming Guide with respect to tab handling. Highlighted reference keys in Algorithms Bibliography. Fixed links in Quick Start Guide.